### PR TITLE
CI: add NUnitTestAdapter and add build status to readme

### DIFF
--- a/NuGetPackages/packages.config
+++ b/NuGetPackages/packages.config
@@ -17,6 +17,7 @@
   <package id="Moq" version="4.8.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" allowedVersions="[10.0.3]" />
   <package id="nunit.framework" version="2.63.0" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" allowedVersions="[2.1.1]" />
   <package id="PetaPoco.Core.Compiled" version="5.1.18" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" allowedVersions="[0.86.0]" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net45" />

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build status](https://dotnetfoundation.visualstudio.com/DNN/_apis/build/status/Dnn.AdminExperience%20%5BCI%5D)](https://dotnetfoundation.visualstudio.com/DNN/_build/latest?definitionId=38)
+
 # Dnn.AdminExperience
 
 The Persona Bar Library, Extensions and EditBar for Dnn (DotNetNuke) is the core of the admin experience in Dnn. 


### PR DESCRIPTION
## Summary

This adds the NUnitTestAdapter to the NuGetPackages project, doing so enables VSTS to detect and run the unit tests included in this solution. This also adds the build status image to the initial readme. 