### PR TITLE
First steps towards improving the accessibility of the PersonaBar.

### DIFF
--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/index.html
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/index.html
@@ -42,7 +42,9 @@
                             'data-hovermenu-id': menuItem.id + 'hovermenu',
                             'data-name': menuItem.displayName,
                             'class': 'btn_panel ' + (menuItem.css || ''),
-                            'href': menuItem.link
+                            'href': menuItem.link,
+                            'aria-haspopup': menuItem.menuItems.length > 0 ? 'true' : null,
+                            'aria-expanded': menuItem.menuItems.length > 0 ? 'false' : null
                         }">
                         <span data-bind="html: menuItem.displayName"></span>
                         <span class="icon-loader" data-bind="visible: menuItem.icon.length > 0, attr: {'data-path': menuItem.icon}"></span>

--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/index.html
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/index.html
@@ -47,7 +47,7 @@
                             'aria-expanded': menuItem.menuItems.length > 0 ? 'false' : null
                         }">
                         <span data-bind="html: menuItem.displayName"></span>
-                        <span class="icon-loader" data-bind="visible: menuItem.icon.length > 0, attr: {'data-path': menuItem.icon}"></span>
+                        <span class="icon-loader" data-bind="visible: menuItem.icon.length > 0, attr: {'data-path': menuItem.icon, 'data-name': menuItem.displayName, 'data-id': menuItem.id}"></span>
                             <!-- ko if: menuItem.menuItems.length > 0 -->
                         <div class="hovermenu" data-bind="
                              attr: { 'id': menuItem.id + 'hovermenu' }, 

--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
@@ -968,6 +968,8 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                                                         });
 
                                                         $hoverMenu.show();
+                                                        $this.attr('aria-expanded', 'true');
+
                                                         // Fix ie personabar hover menús
                                                         showMenuHandlers.push(setTimeout(function () {
                                                             $('.hovermenu > ul').css('list-style-type', 'square');
@@ -997,6 +999,7 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                                                             $iframe.width(personaBarMenuWidth);
                                                         }
                                                         $hoverMenu.hide();
+                                                        $this.attr('aria-expanded', 'false');
 
                                                         resetHandlers();
                                                     }

--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
@@ -967,6 +967,7 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                                                             $('#' + hoverMenuId).hide();
                                                         });
 
+                                                        // Set aria-expanded to true when menu is shown
                                                         $hoverMenu.show();
                                                         $this.attr('aria-expanded', 'true');
 
@@ -998,6 +999,7 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                                                         if (!activePath) {
                                                             $iframe.width(personaBarMenuWidth);
                                                         }
+                                                        // Set aria-expanded to false when menu is hidden
                                                         $hoverMenu.hide();
                                                         $this.attr('aria-expanded', 'false');
 

--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/menuIconLoader.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/menuIconLoader.js
@@ -1,13 +1,36 @@
 'use strict';
 define(['jquery', 'main/config'], function ($, cf) {
     var config = cf.init();
-    var loadImage = function(wrapper, path) {
-        wrapper.append($('<img />').attr('src', path));
+    var loadImage = function(wrapper, path, alt) {
+        wrapper.append($('<img />').attr({
+            'src': path,
+            'alt': alt
+        }));
     }
 
-    var loadSvg = function (wrapper, path) {
+    var loadSvg = function (wrapper, path, alt, iconId) {
         $.get(path, {}, function (data) {
-            wrapper.html(data);
+            wrapper.html(function () {
+                /* Add a <title> element to the SVG, and an aria-labelledby attribute to help assistive technology */
+                var titleId = iconId + '_title';
+                var $titleEl = $('<title id="' + titleId + '">' + alt + '</title>');
+                var svgIcon = $.parseHTML($.trim(data), null, false);
+
+                /* Make sure there isn't already a <title> */
+                if ($(svgIcon).has('title') === true) {
+                    $(svgIcon)
+                        .attr('aria-labelledby', titleId)
+                        .find('title')
+                        .replaceWith($titleEl);
+                }
+                else {
+                    $(svgIcon)
+                        .attr('aria-labelledby', titleId)
+                        .prepend($titleEl);
+                }
+                return $(svgIcon);
+            });
+
         }, 'text');
     }
 
@@ -15,6 +38,8 @@ define(['jquery', 'main/config'], function ($, cf) {
         $('#personabar .personabarnav span.icon-loader').each(function() {
             var $this = $(this);
             var path = $this.data('path');
+            var alt = $this.data('name');
+            var iconId = $this.data('id');
             if (!path) {
                 return;
             }
@@ -25,9 +50,9 @@ define(['jquery', 'main/config'], function ($, cf) {
 
             var ext = path.split('?')[0].split('.').pop().toLowerCase();
             if (ext === "svg") {
-                loadSvg($this, path);
+                loadSvg($this, path, alt, iconId);
             } else {
-                loadImage($this, path);
+                loadImage($this, path, alt);
             }
 
             $this.data('path', null);


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a correcponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->

First attempt at fixing #32 and #34:

- Adds `aria-haspopup` and `aria-expanded` attributes to relevant icons in the main PersonaBar.
- When menus become visible, set `aria-expanded` to `true` (and back to `false` when they're hidden)
- Add alt text to the icons - via a `<title>` element when it's an SVG

Release Note: First steps towards improving the accessibility of the PersonaBar.

Testing Steps: Compare before and after using the accessibility pane in Firefox's developer tools. Would also be a good idea to get some help from someone using assistive technology.

This is my first pull request on DNN, so be gentle ;-)