### PR TITLE
Added back host email setting in smtp server configuration

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.Servers/Servers.Web/src/components/Tabs/SmtpServer.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/Servers.Web/src/components/Tabs/SmtpServer.jsx
@@ -61,6 +61,7 @@ class SmtpServer extends Component {
             smtpAuthentication: smtpSettings.smtpAuthentication,
             smtpUsername: smtpSettings.smtpUserName,
             smtpPassword: smtpSettings.smtpPassword,
+            smtpHostEmail: smtpSettings.smtpHostEmail,
             enableSmtpSsl: smtpSettings.enableSmtpSsl,
             messageSchedulerBatchSize: props.smtpServerInfo.host.messageSchedulerBatchSize
         };
@@ -197,7 +198,7 @@ class SmtpServer extends Component {
                                     isGlobal={areGlobalSettings} />
                         </div>
                     }
-                    <div className="tooltipAdjustment">
+                    <div className="tooltipAdjustment border-bottom">
                         {smtpSettingsVisible && credentialVisible && 
                             <div>
                                 <EditBlock label={localization.get("plSMTPUsername")}
@@ -226,6 +227,14 @@ class SmtpServer extends Component {
                             isGlobal={areGlobalSettings} />
                         }              
                     </div>
+                    {smtpSettingsVisible && areGlobalSettings &&
+                        <EditBlock label={localization.get("plHostEmail")}
+                            tooltip={localization.get("plHostEmail.Help")}
+                            value={selectedSmtpSettings.smtpHostEmail}
+                            isGlobal={true}
+                            onChange={this.onChangeField.bind(this, "smtpHostEmail")}
+                            error={props.errors["smtpHostEmail"]} />
+                    }
                 </div>
             </GridSystem>
             <div className="clear" />

--- a/Extensions/Settings/Dnn.PersonaBar.Servers/Services/Dto/UpdateSMTPSettingsRequest.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/Services/Dto/UpdateSMTPSettingsRequest.cs
@@ -37,6 +37,8 @@ namespace Dnn.PersonaBar.Servers.Services.Dto
 
         public string SmtpPassword { get; set; }
 
+        public string SmtpHostEmail { get; set; }
+
         public bool EnableSmtpSsl { get; set; }
 
         public int MessageSchedulerBatchSize { get; set; }

--- a/Extensions/Settings/Dnn.PersonaBar.Servers/Services/ServerSettingsSmtpHostController.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/Services/ServerSettingsSmtpHostController.cs
@@ -63,6 +63,7 @@ namespace Dnn.PersonaBar.Servers.Services
                         enableSmtpSsl = HostController.Instance.GetBoolean("SMTPEnableSSL", false),
                         smtpUserName = HostController.Instance.GetString("SMTPUsername"),
                         smtpPassword = GetSmtpPassword(),
+                        smtpHostEmail = HostController.Instance.GetString("HostEmail"),
                         messageSchedulerBatchSize = Host.MessageSchedulerBatchSize
                     },
                     site = new 
@@ -104,6 +105,7 @@ namespace Dnn.PersonaBar.Servers.Services
                     HostController.Instance.Update("SMTPUsername", request.SmtpUsername, false);
                     HostController.Instance.UpdateEncryptedString("SMTPPassword", request.SmtpPassword,
                         Config.GetDecryptionkey());
+                    HostController.Instance.Update("HostEmail", request.SmtpHostEmail);
                     HostController.Instance.Update("SMTPEnableSSL", request.EnableSmtpSsl ? "Y" : "N", false);
                     HostController.Instance.Update("MessageSchedulerBatchSize",
                         request.MessageSchedulerBatchSize.ToString(), false);

--- a/Extensions/Settings/Dnn.PersonaBar.Servers/admin/personaBar/App_LocalResources/Servers.resx
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/admin/personaBar/App_LocalResources/Servers.resx
@@ -621,4 +621,10 @@ Are you sure you want to increment the version number for your site?</value>
   <data name="VersionIncrementedConfirmation.Text" xml:space="preserve">
     <value>Version incremented successfully</value>
   </data>
+  <data name="plHostEmail.Help" xml:space="preserve">
+    <value>The host email is used when testing the mail server, it can also be used by extensions to reach the person responsible for the hosting.</value>
+  </data>
+  <data name="plHostEmail.Text" xml:space="preserve">
+    <value>Host Email</value>
+  </data>
 </root>


### PR DESCRIPTION
# Testing steps:
- Go to Settings -> Servers -> Server Settings -> SMTP Server
- Change the host email and save
- Go to Settings -> SQL Console
- Enter the following query: 
```SQL
SELECT SettingValue FROM {databaseOwner}{objectQualifier}HostSettings
WHERE SettingName = 'HostEmail'
```
- Make sure the returned email is the one entered in the UI

# Context
The host email is used in a couple places in the platform, see https://github.com/dnnsoftware/Dnn.Platform/search?q=hostemail&unscoped_q=hostemail
It can also be used by module developers to send a message to the person responsible for hosting the possibly multiple sites.
Since Dnn 9 and the persona bar came out, the only way to change this host email was to edit the database directly.

closes #6 

This is my first pull request for the persona bar, if I did anything wrong or not following best practices, please comment.