### PR TITLE
Update build script to handle differences between editbar and extensions

### DIFF
--- a/Build/BuildScripts/Module.build
+++ b/Build/BuildScripts/Module.build
@@ -1,7 +1,11 @@
 ﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\Yarn.MSBuild.1.7.0\build\Yarn.MSBuild.props" Condition="Exists('..\..\packages\Yarn.MSBuild.1.7.0\build\Yarn.MSBuild.props')" />
   <Import Project="..\..\packages\Yarn.MSBuild.1.7.0\build\Yarn.MSBuild.targets" Condition="Exists('..\..\packages\Yarn.MSBuild.1.7.0\build\Yarn.MSBuild.targets')" />
-  
+
+  <PropertyGroup>
+    <ResourceZipWorkingDirectory>$(MSBuildProjectDirectory)\Package\Resources\admin\personaBar</ResourceZipWorkingDirectory>
+  </PropertyGroup>
+
   <Target Name="AfterBuild" DependsOnTargets="RunYarn;CopyBin;GetFiles;DebugProject;Package">
   </Target>
   <Target Name="GetFiles">

--- a/Build/BuildScripts/Package.targets
+++ b/Build/BuildScripts/Package.targets
@@ -66,7 +66,7 @@
     <Exec Command="$(yuicompressor) -v &quot;%(_CSSFilesToCompress.FullPath)&quot; &gt; &quot;$(MSBuildProjectDirectory)\Package\Resources\%(_CSSFilesToCompress.RecursiveDir)%(_CSSFilesToCompress.Filename)%(_CSSFilesToCompress.Extension)&quot;"
           Condition="Exists(%(_CSSFilesToCompress.FullPath))" ContinueOnError="false" />
 
-    <Zip Files="@(_Step2FilesToZip)" WorkingDirectory="$(MSBuildProjectDirectory)\Package\Resources\admin\personaBar"
+    <Zip Files="@(_Step2FilesToZip)" WorkingDirectory="$(ResourceZipWorkingDirectory)"
          ZipFileName="$(MSBuildProjectDirectory)\Package\Resources.zip" />
     <RemoveDir Directories ="$(MSBuildProjectDirectory)\Package\Resources" ContinueOnError="WarnAndContinue" />
   </Target>

--- a/EditBar/Dnn.EditBar.UI/Module.build
+++ b/EditBar/Dnn.EditBar.UI/Module.build
@@ -1,14 +1,29 @@
 ﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(SolutionDir)\Solution.build" />
+    <Import Project="$(BuildScriptsPath)\Package.Targets" />
+    <Import Project="$(BuildScriptsPath)\Module.Build"/>
+  
     <PropertyGroup>
         <Extension>zip</Extension>
         <DNNFileName>Dnn.EditBar.UI</DNNFileName>
         <PackageName>Dnn.EditBar.UI</PackageName>
         <ModuleFolderName>$(WebsitePath)\DesktopModules\admin\Dnn.EditBar</ModuleFolderName>
+        <ResourceZipWorkingDirectory>$(MSBuildProjectDirectory)\Package\Resources\editBar</ResourceZipWorkingDirectory>
     </PropertyGroup>
-    <Import Project="$(BuildScriptsPath)\Package.Targets" />
-    <Import Project="$(BuildScriptsPath)\Module.Build"/>
+    
 
+    <Target Name="GetFiles">
+    <ItemGroup>
+      <EditBar-views Include=".\editBar\*.html" />
+      <EditBar-images Include=".\editBar\images\**\*" />
+      <EditBar-css Include=".\editBar\css\**\*" />
+      <EditBar-resources Include=".\editBar\App_LocalResources\*.resx" />
+      <EditBar-scripts Include=".\editBar\scripts\**\*" />
+      <EditBar-moduleResources Include=".\editBar\Resources\**\**\*.*" />
+      <Resources Include="@(EditBar-views);@(EditBar-images);@(EditBar-css);@(EditBar-scripts);@(EditBar-resources);@(EditBar-moduleResources)" />
+    </ItemGroup>
+  </Target>
+    
     <Target Name="CopyBin">
         <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\$(AssemblyName).dll" DestinationFolder="$(WebsitePath)/bin" />
         <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\$(AssemblyName).pdb" DestinationFolder="$(WebsitePath)/bin" />
@@ -17,4 +32,12 @@
         <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\Dnn.EditBar.Library.pdb" DestinationFolder="$(WebsitePath)/bin" />
         <Copy SourceFiles="$(MSBuildProjectDirectory)\bin\Dnn.EditBar.Library.xml" DestinationFolder="$(WebsitePath)/bin" />
     </Target>
+    <Target Name="DebugProject" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <Copy SourceFiles="@(EditBar-views)" DestinationFolder="$(ModuleFolderName)" />
+        <Copy SourceFiles="@(EditBar-resources)" DestinationFolder="$(ModuleFolderName)\App_LocalResources" />
+        <Copy SourceFiles="@(EditBar-images)" DestinationFolder="$(ModuleFolderName)\Images" />
+        <Copy SourceFiles="@(EditBar-scripts)" DestinationFolder="$(ModuleFolderName)\Scripts" />
+        <Copy SourceFiles="@(EditBar-css)" DestinationFolder="$(ModuleFolderName)\Css" />
+        <Copy SourceFiles="@(EditBar-moduleResources)" DestinationFolder="$(ModuleFolderName)\Resources" />
+  </Target>
 </Project>


### PR DESCRIPTION
In our combination of PersonaBar projects, I made a mistake and didn't catch a few differences in the build scripts. This updates the master build script and adds a new ResourceZipWorkingDirectory property so we can update the path for compression the resources included with each extension. It also adds the EditBar-* paths into the EditBar module.build file. 

This is targeting the development branch.