### PR TITLE
After export with Content Localization site language flags…

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Sites/Components/SitesController.cs
+++ b/Extensions/Manage/Dnn.PersonaBar.Sites/Components/SitesController.cs
@@ -573,14 +573,11 @@ namespace Dnn.PersonaBar.Sites.Components
                     // mark default language as published if content localization is enabled
                     var ContentLocalizationEnabled = PortalController.GetPortalSettingAsBoolean("ContentLocalizationEnabled", PortalSettings.PortalId,
                         false);
+                    
+                    LocaleController.Instance.PublishLanguage(intPortalId, PortalSettings.DefaultLanguage, true);
                     if (ContentLocalizationEnabled)
                     {
-                        var lc = new LocaleController();
-                        var publishedLocales = lc.GetPublishedLocales(PortalSettings.PortalId);
-                        foreach(var locale in publishedLocales)
-                        {
-                            lc.ActivateLanguage(intPortalId, objPortal.CultureCode, true);
-                        }
+                        PortalController.UpdatePortalSetting(intPortalId, "ContentLocalizationEnabled", Boolean.TrueString);
                     }
 
                     //Redirect to this new site

--- a/Extensions/Manage/Dnn.PersonaBar.Sites/Components/SitesController.cs
+++ b/Extensions/Manage/Dnn.PersonaBar.Sites/Components/SitesController.cs
@@ -576,7 +576,11 @@ namespace Dnn.PersonaBar.Sites.Components
                     if (ContentLocalizationEnabled)
                     {
                         var lc = new LocaleController();
-                        lc.PublishLanguage(intPortalId, objPortal.DefaultLanguage, true);
+                        var publishedLocales = lc.GetPublishedLocales(PortalSettings.PortalId);
+                        foreach(var locale in publishedLocales)
+                        {
+                            lc.ActivateLanguage(intPortalId, objPortal.CultureCode, true);
+                        }
                     }
 
                     //Redirect to this new site


### PR DESCRIPTION
### Summary
After export with Content Localization site language flags disappear.

### Bug
When creating a child site after enabling content localization, not all published locales were activated.
### Fix
Enabled published locales when creating a child portal.

fixes dnnsoftware/Dnn.Platform#2294