### PR TITLE
Ignore hash url when switching to Edit mode

### DIFF
--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/main.js
@@ -1060,7 +1060,7 @@ require(['jquery', 'knockout', 'moment', '../util', '../sf', '../config', './../
                                         util.closePersonaBar(function () {
                                             toogleUserMode('EDIT', function() {
                                                 function reloadPage() {
-                                                    window.top.location.replace(window.top.location.href);
+                                                    window.top.location.replace(window.top.location.pathname);
                                                 }
                                                 saveBtnEditSettings(reloadPage, reloadPage);
                                             });


### PR DESCRIPTION
## Summary
Fixed problem: when URL contains a hash, edit and close button not working.
They are based on window.location.reload, so by appending an hash, reload was not triggered.

fix for dnnsoftware/Dnn.Platform#2330