### PR TITLE
Added small and large icons to pages editor

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
@@ -797,6 +797,25 @@ namespace Dnn.PersonaBar.Pages.Components
                     }
                 }
             }
+
+            // icons
+            if (pageSettings.IconFile != null && pageSettings.IconFile.fileId > 0)
+            {
+                tab.IconFile = FileManager.Instance.GetFile(pageSettings.IconFile.fileId).RelativePath;
+            }
+            else
+            {
+                tab.IconFile = null;
+            }
+            if (pageSettings.IconFileLarge != null && pageSettings.IconFileLarge.fileId > 0)
+            {
+                tab.IconFileLarge = FileManager.Instance.GetFile(pageSettings.IconFileLarge.fileId).RelativePath;
+            }
+            else
+            {
+                tab.IconFileLarge = null;
+            }
+            
         }
 
         private string GetContainerSrc(PageSettings pageSettings)
@@ -1047,6 +1066,30 @@ namespace Dnn.PersonaBar.Pages.Components
             page.PrimaryAliasId = GetPrimaryAliasId(portalSettings.PortalId, portalSettings.CultureCode);
             page.Locales = GetLocales(portalSettings.PortalId);
             page.HasParent = tab.ParentId > -1;
+
+            // icons
+            var iconFile = string.IsNullOrEmpty(tab.IconFile) ? null : FileManager.Instance.GetFile(tab.PortalID, tab.IconFileRaw);
+            if (iconFile != null) {
+                page.IconFile = new FileDto
+                {
+                    fileId = iconFile.FileId,
+                    fileName = iconFile.FileName,
+                    folderId = iconFile.FolderId,
+                    folderPath = iconFile.Folder
+                };
+            }
+            var iconFileLarge = string.IsNullOrEmpty(tab.IconFileLarge) ? null : FileManager.Instance.GetFile(tab.PortalID, tab.IconFileLargeRaw);
+            if (iconFileLarge != null)
+            {
+                page.IconFileLarge = new FileDto
+                {
+                    fileId = iconFileLarge.FileId,
+                    fileName = iconFileLarge.FileName,
+                    folderId = iconFileLarge.FolderId,
+                    folderPath = iconFileLarge.Folder
+                };
+            }
+
             return page;
         }
 

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Dnn.PersonaBar.Pages.csproj
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Dnn.PersonaBar.Pages.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Services\Dto\DnnPageDto.cs" />
     <Compile Include="Services\Dto\DnnPagesRequest.cs" />
     <Compile Include="Services\Dto\DnnPagesDto.cs" />
+    <Compile Include="Services\Dto\FileDto.cs" />
     <Compile Include="Services\Dto\ModuleCopyType.cs" />
     <Compile Include="Services\Dto\ModuleItem.cs" />
     <Compile Include="Services\Dto\PageFolderTemplate.cs" />

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/.eslintskipwords.js
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/.eslintskipwords.js
@@ -150,5 +150,8 @@ module.exports = [
     "flyout",
     "Flyout",
     "interactor",
-    "cloneDeep"
+    "cloneDeep",
+    "bmp",
+    "xml",
+    "filesystem"
 ]

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageDetails.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageDetails.jsx
@@ -4,6 +4,7 @@ import {connect} from "react-redux";
 import PageStandard from "./PageStandard/PageStandard";
 import PageUrl from "./PageUrl/PageUrl";
 import PageDetailsFooter from "./PageDetailsFooter/PageDetailsFooter";
+import PageIcons from "./PageIcons/PageIcons";
 
 class PageDetail extends Component {
 
@@ -27,6 +28,7 @@ class PageDetail extends Component {
         return (
             <div>
                 <DetailComponent onChangeField={this.props.onChangeField} errors={this.props.errors} onSelectParentPageId={this.props.onSelectParentPageId}/>
+                <PageIcons components={this.props.components} onChangeField={this.props.onChangeField} errors={this.props.errors} page={this.props.page} />
                 <PageDetailsFooter components={this.props.components} onChangeField={this.props.onChangeField} errors={this.props.errors} />
             </div>
         );
@@ -43,7 +45,7 @@ PageDetail.propTypes = {
 
 const mapStateToProps = (state) => {
     return {
-        page: state.pages.selectedPage
+        page: state.pages.selectedPage        
     };
 };
 

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageIcons/PageIcons.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageIcons/PageIcons.jsx
@@ -1,0 +1,100 @@
+import React, {Component} from "react";
+import PropTypes from "prop-types";
+import FileUpload from 'dnn-file-upload';
+import GridSystem from "dnn-grid-system";
+import GridCell from "dnn-grid-cell";
+import Label from 'dnn-label';
+import Localization from '../../../localization';
+import util from '../../../utils';
+import styles from './styles.less';
+
+export default class PageIcons extends Component {            
+    constructor(props) {
+        super(props);  
+    }    
+
+    onChangeIcon(key, fileInfo) {        
+        const {onChangeField} = this.props;
+        onChangeField(key, fileInfo);
+    }
+
+    render() {
+        const {props} = this;  
+        util.utilities = util.getUtilities();
+        return (
+            <div className={styles.pageIcons}>
+                <GridSystem>
+                    <GridCell className="left-column">
+                        <Label 
+                            tooltipMessage={Localization.get("IconFile.Help")}
+                            label={Localization.get("IconFile")}                        
+                        />
+                        <FileUpload 
+                            utils={util}
+                            onSelectFile={this.onChangeIcon.bind(this, 'iconFile')}
+                            selectedFile={props.page.iconFile}
+                            folderName={props.page.iconFile ? props.page.iconFile.folderName: null}
+                            fileFormats={["image/png", "image/jpg", "image/jpeg", "image/bmp", "image/gif", "image/svg+xml"]}
+                            browseActionText={Localization.get("BrowseAction")}                         // Press {save|[ENTER]} to save, or {cancel|[ESC]} to cancel
+                            browseButtonText={Localization.get("BrowseButton")}                         // Browse Filesystem
+                            defaultText={Localization.get("DragOver")}                                  // Drag and Drop a File                            
+                            fileText={Localization.get("File")}                                         // File
+                            folderText={Localization.get("Folder")}                                     // Folder
+                            imageText={Localization.get("DefaultImageTitle")}                           // Image
+                            linkButtonText={Localization.get("LinkButton")}                             // Enter URL Link
+                            linkInputActionText={Localization.get("LinkInputAction")}                   // Press {save|[ENTER]} to save, or {cancel|[ESC]} to cancel
+                            linkInputPlaceholderText={Localization.get("LinkInputPlaceholder")}         // http://example.com/imagename.jpg
+                            linkInputTitleText={Localization.get("LinkInputTitle")}                     // URL Link
+                            notSpecifiedText={Localization.get("NoneSpecified")}                        // <None Specified>
+                            searchFilesPlaceHolderText={Localization.get("SearchFilesPlaceHolder")}                // Search Files...
+                            searchFoldersPlaceHolderText={Localization.get("SearchFoldersPlaceholder")} // Search Folders...
+                            uploadButtonText={Localization.get("UploadButton")}                         // Upload a File
+                            uploadCompleteText={Localization.get("UploadComplete")}                     // Upload Complete
+                            uploadingText={Localization.get("Uploading")}                               // Uploading...                            
+                            uploadFailedText={Localization.get("UploadFailed")}                         // Upload Failed
+                            wrongFormatText={Localization.get("WrongFormat")}                           // wrong format                            
+                        />
+                    </GridCell>
+                    <GridCell className="right-column">
+                        <Label 
+                            tooltipMessage={Localization.get("IconFileLarge.Help")}
+                            label={Localization.get("IconFileLarge")}                        
+                        />
+                        <FileUpload 
+                            utils={util}
+                            onSelectFile={this.onChangeIcon.bind(this, 'iconFileLarge')}
+                            selectedFile={props.page.iconFileLarge}
+                            folderName={props.page.iconFileLarge ? props.page.iconFileLarge.folderName : null}
+                            fileFormats={["image/png", "image/jpg", "image/jpeg", "image/bmp", "image/gif", "image/svg+xml"]}
+                            browseActionText={Localization.get("BrowseAction")}                         // Press {save|[ENTER]} to save, or {cancel|[ESC]} to cancel
+                            browseButtonText={Localization.get("BrowseButton")}                         // Browse Filesystem
+                            defaultText={Localization.get("DragOver")}                                  // Drag and Drop a File                            
+                            fileText={Localization.get("File")}                                         // File
+                            folderText={Localization.get("Folder")}                                     // Folder
+                            imageText={Localization.get("DefaultImageTitle")}                           // Image
+                            linkButtonText={Localization.get("LinkButton")}                             // Enter URL Link
+                            linkInputActionText={Localization.get("LinkInputAction")}                   // Press {save|[ENTER]} to save, or {cancel|[ESC]} to cancel
+                            linkInputPlaceholderText={Localization.get("LinkInputPlaceholder")}         // http://example.com/imagename.jpg
+                            linkInputTitleText={Localization.get("LinkInputTitle")}                     // URL Link
+                            notSpecifiedText={Localization.get("NoneSpecified")}                        // <None Specified>
+                            searchFilesPlaceHolderText={Localization.get("SearchFilesPlaceHolder")}                // Search Files...
+                            searchFoldersPlaceHolderText={Localization.get("SearchFoldersPlaceholder")} // Search Folders...
+                            uploadButtonText={Localization.get("UploadButton")}                         // Upload a File
+                            uploadCompleteText={Localization.get("UploadComplete")}                     // Upload Complete
+                            uploadingText={Localization.get("Uploading")}                               // Uploading...                            
+                            uploadFailedText={Localization.get("UploadFailed")}                         // Upload Failed
+                            wrongFormatText={Localization.get("WrongFormat")}                           // wrong format                            
+                        />
+                    </GridCell>
+                </GridSystem>
+            </div>
+        );
+    }
+}
+
+PageIcons.propTypes = {
+    page: PropTypes.object.isRequired,
+    errors: PropTypes.object.isRequired,
+    onChangeField: PropTypes.func.isRequired,
+    components: PropTypes.func.isRequired
+};

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageIcons/styles.less
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageIcons/styles.less
@@ -1,0 +1,25 @@
+@import "../../../less/globals.less";
+@import "~dnn-global-styles/index";
+:local(.pageIcons) {
+    .dnn-file-upload{
+        width:100%;
+        .file-upload-container{
+            .drop-down{
+                margin-bottom: 7px;
+            }
+        }
+    }
+    .dnn-grid-system {
+        margin-top:15px;
+        margin-bottom:15px;
+        .left-column{
+            padding-right:15px;
+        }
+        .right-column{
+            padding-left:15px;
+        }
+    }
+    .dnn-label{
+        padding-bottom:10px;
+    }
+}

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/services/pageService.js
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/services/pageService.js
@@ -91,6 +91,8 @@ const PageService = function () {
                 page.hasParent = parentPage && typeof parentPage !== "function" && parentPage.id || page.hasParent;
                 page.hierarchy = parentPage && typeof parentPage !== "function" && parentPage.id && parentPage.name || page.hierarchy;
                 page.parentId = parentPage && typeof parentPage !== "function" && parentPage.id || page.parentId;
+                page.iconFile = null;
+                page.iconFileLarge = null;
                 return page;
             });
     };

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Services/Dto/FileDto.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Services/Dto/FileDto.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Dnn.PersonaBar.Pages.Services.Dto
+{
+    [JsonObject]
+    public class FileDto
+    {
+        public int fileId { get; set; }
+        public string fileName { get; set; }
+        public int folderId { get; set; }
+        public string folderPath { get; set; }
+    }
+}

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Services/Dto/PageSettings.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Services/Dto/PageSettings.cs
@@ -175,5 +175,11 @@ namespace Dnn.PersonaBar.Pages.Services.Dto
 
         [DataMember(Name = "isspecial")]
         public bool IsSpecial { get; set; }
+
+        [DataMember(Name = "iconFile")]
+        public FileDto IconFile { get; set; }
+
+        [DataMember(Name = "iconFileLarge")]
+        public FileDto IconFileLarge { get; set; }
     }
 }

--- a/Extensions/Content/Dnn.PersonaBar.Pages/admin/personaBar/App_LocalResources/Pages.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/admin/personaBar/App_LocalResources/Pages.resx
@@ -1690,4 +1690,16 @@
   <data name="EditContent.Text" xml:space="preserve">
     <value>Edit Content</value>
   </data>
+  <data name="IconFile.Help" xml:space="preserve">
+    <value>The page icon is an image that may be used by your theme or menu system for each page</value>
+  </data>
+  <data name="IconFile.Text" xml:space="preserve">
+    <value>Small Icon</value>
+  </data>
+  <data name="IconFileLarge.Help" xml:space="preserve">
+    <value>The page icon is an image that may be used by your theme or menu system for each page</value>
+  </data>
+  <data name="IconFileLarge.Text" xml:space="preserve">
+    <value>Large Icon</value>
+  </data>
 </root>


### PR DESCRIPTION
Closes #109 

## Summary
Adds back a UI to set icons on pages (small and large icon).
This feature was part of Dnn already and all the backend still works, it was just missing a UI to manage those images. I have tried to implement it as much as possible as the Portal Logo and favIcon for a consistent user experience
