### PR TITLE
Exposing AllTabs attribute

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Pages/Components/Converters.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Components/Converters.cs
@@ -58,7 +58,8 @@ namespace Dnn.PersonaBar.Pages.Components
             FriendlyName = module.DesktopModule.FriendlyName,
             EditContentUrl = GetModuleEditContentUrl(module),
             EditSettingUrl = GetModuleEditSettingUrl(module),
-            IsPortable = module.DesktopModule?.IsPortable
+            IsPortable = module.DesktopModule?.IsPortable,
+            AllTabs = module.AllTabs
         };
 
         private static string GetModuleEditSettingUrl(ModuleInfo module)

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
@@ -486,7 +486,7 @@ namespace Dnn.PersonaBar.Pages.Components
         public IEnumerable<ModuleInfo> GetModules(int pageId)
         {
             var tabModules = _moduleController.GetTabModules(pageId);
-            return tabModules.Values.Where(m => !m.IsDeleted && !m.AllTabs);
+            return tabModules.Values.Where(m => !m.IsDeleted);
         }
 
         protected virtual bool ValidatePageSettingsData(PortalSettings portalSettings, PageSettings pageSettings, TabInfo tab, out string invalidField, out string errorMessage)

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Modules/ModuleRow/ModuleRow.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Modules/ModuleRow/ModuleRow.jsx
@@ -43,7 +43,7 @@ class ModuleRow extends Component {
                             className={editClassName} 
                             onClick={onSetting.bind(this, module)} 
                             dangerouslySetInnerHTML={{ __html: SettingsIcon }}></div>
-                        {module.editContentUrl && 
+                        {module.allTabs === false && module.editContentUrl &&
                             <div 
                                 className={editClassName} 
                                 onClick={onEditing.bind(this, module)} 

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Services/Dto/ModuleItem.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Services/Dto/ModuleItem.cs
@@ -28,5 +28,8 @@ namespace Dnn.PersonaBar.Pages.Services.Dto
 
         [DataMember(Name = "isPortable")]
         public bool? IsPortable { get; set; }
+
+        [DataMember(Name = "allTabs")]
+        public bool AllTabs { get; set; }
     }
 }


### PR DESCRIPTION
When a module is shared across pages, it's not listed in *Page Settings -> Modules*. 
This change will make shared module visible and editable in the modules list of all pages.