### PR TITLE
Persona Bar: Pages: Wrong Container Selected

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/actions/themeActions.js
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/actions/themeActions.js
@@ -3,7 +3,7 @@ import ThemeService from "../services/themeService";
 
 const themeActions = {
     retrieveThemes() {
-        return (dispatch) => {
+        return (dispatch) => new Promise(function(callback) {
             dispatch({
                 type: ActionTypes.RETRIEVING_THEMES
             });    
@@ -18,14 +18,16 @@ const themeActions = {
                         defaultPortalLayout: response.defaultPortalLayout,
                         defaultPortalContainer: response.defaultPortalContainer
                     }
-                });  
+                });
+                callback({success: true});
             }).catch((error) => {
                 dispatch({
                     type: ActionTypes.ERROR_RETRIEVING_THEMES,
                     data: {error}
                 });
+                callback({success: false});
             });     
-        };
+        });
     },
 
     retrieveThemeFiles(themeName, level) {

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Appearance/Appearance.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Appearance/Appearance.jsx
@@ -15,15 +15,19 @@ import style from "./style.less";
 class Appearance extends Component {
 
     componentWillMount() {
-        const { page, defaultPortalThemeName, defaultPortalThemeLevel, onRetrieveThemes, onRetrieveThemeFiles } = this.props;
+        const { page, onRetrieveThemes, onRetrieveThemeFiles } = this.props;
 
-        onRetrieveThemes();
-
-        const selectedThemeName = page.themeName || defaultPortalThemeName;
-        const selectedThemeLevel = page.themeLevel || defaultPortalThemeLevel;
-        if (selectedThemeName) {
-            onRetrieveThemeFiles(selectedThemeName, selectedThemeLevel);
-        }
+        onRetrieveThemes().then(data => {
+			if(!data || data.success === false) {
+				return;
+			}
+			const { defaultPortalThemeName, defaultPortalThemeLevel } = this.props;
+			const selectedThemeName = page.themeName || defaultPortalThemeName;
+			const selectedThemeLevel = page.themeLevel || defaultPortalThemeLevel;
+			if (selectedThemeName) {
+				onRetrieveThemeFiles(selectedThemeName, selectedThemeLevel);
+			}
+		});
     }
 
     componentWillReceiveProps(newProps) {


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/134

When loading appearance tab, there are two api calls:
- `onRetrieveThemes`: get list of available themes and default portal theme/container
- `onRetrieveThemeFiles`: get list of available layouts and containers

Both api's are invoked asynchronously. 

Increasing number of themes in a Skin folder makes the first call completed later than the second one. At the moment when containers list is already received we don't have default value of container. It causes application to choose the first one in the list. This also explains why this issue is not reproducible having small amount of themes. Operation of reading from file system is heavy and ideally, installing themes in a correct way also installs more containers and layouts. So it makes some balance when executing above calls. In our particular case we increased skins only and this problem became visible.

To fix it, we need to make sure above calls are executed consistently, when first is completed and all themes including default values received, we raise second one. We can use `Promise` feature and invoke second api call when asynchronous call is resolved.