### PR TITLE
DNN-26583 fixed CSS issue

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/UsersInRole/UserRow/style.less
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/UsersInRole/UserRow/style.less
@@ -68,6 +68,9 @@
             }
         }
     }
+    .dnn-grid-cell:last-child {
+        overflow: visible;
+    }
     &:hover {
         .dnn-grid-cell {
             .actions {


### PR DESCRIPTION
Avoid overflow:hidden on last GridCell element to make popup calendar visible.