### PR TITLE
Content Localization: shared module un-published after changes

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/Module.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/Module.jsx
@@ -35,7 +35,7 @@ class Module extends Component {
 
         if (module.Exist) {
             const className = "module-row" + (module.IsDeleted ? " deleted" : "");
-            const toolTip = ["Shared: " + module.IsShared, module.ModuleInfoHelp].join("<br>");
+            const toolTip = [Localization.get("Shared") + ": " + module.IsShared, module.ModuleInfoHelp].join("<br>");
             return <div className={className}>
                 <Tooltip
                     messages={[toolTip]}

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/Module.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/Module.jsx
@@ -35,7 +35,7 @@ class Module extends Component {
 
         if (module.Exist) {
             const className = "module-row" + (module.IsDeleted ? " deleted" : "");
-            const toolTip = [Localization.get("Shared") + ": " + module.IsShared, module.ModuleInfoHelp].join("<br>");
+            const toolTip = [module.IsShared ? Localization.get("SharedModule") : Localization.get("IsNotSharedModule"), module.ModuleInfoHelp].join("<br>");
             return <div className={className}>
                 <Tooltip
                     messages={[toolTip]}

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/Module.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/Module.jsx
@@ -35,9 +35,10 @@ class Module extends Component {
 
         if (module.Exist) {
             const className = "module-row" + (module.IsDeleted ? " deleted" : "");
+            const toolTip = ["Shared: " + module.IsShared, module.ModuleInfoHelp].join("<br>");
             return <div className={className}>
                 <Tooltip
-                    messages={[module.ModuleInfoHelp]}
+                    messages={[toolTip]}
                     style={{ float: "left", position: "static" }}
                     />
                 <input type="text" value={module.ModuleTitle} onChange={this.onUpdateModules.bind(this, "ModuleTitle") } aria-label="Title"/>
@@ -47,7 +48,7 @@ class Module extends Component {
                 </div>}
                 {!module.IsDeleted && !isDefault && <div className="icons-container">
                     <span
-                        className={`icon float-left ${(module.IsLocalized ? " blue" : "")}`}
+                        className={`icon float-left ${(module.IsShared ? " disabled" : (module.IsLocalized ? " blue" : ""))}`}
                         onClick={this.toggleLink.bind(this) }
                         dangerouslySetInnerHTML={{ __html: LinkIcon }} />
                     {module.TranslatedVisible && <Checkbox

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.jsx
@@ -21,6 +21,9 @@ class PageLanguage extends Component {
         const {modules} = this.props;
         const CultureCode = this.props.local.CultureCode;
         modules.forEach((module, index) => {
+            if (module.IsShared && key === "IsLocalized") {
+				return;
+            }
             this.props.onUpdateModules(CultureCode, index, value, key);
         });
     }

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.jsx
@@ -22,7 +22,7 @@ class PageLanguage extends Component {
         const CultureCode = this.props.local.CultureCode;
         modules.forEach((module, index) => {
             if (module.IsShared && key === "IsLocalized") {
-				return;
+                return;
             }
             this.props.onUpdateModules(CultureCode, index, value, key);
         });

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.less
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.less
@@ -45,6 +45,9 @@
                     fill: @curiousBlue;
                 }
             }
+            &.disabled {
+				pointer-events: none;
+            }
         }
         .page-language-row-header {
             width: 100%;

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.less
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageLocalization/PageLanguage.less
@@ -46,7 +46,7 @@
                 }
             }
             &.disabled {
-				pointer-events: none;
+                pointer-events: none;
             }
         }
         .page-language-row-header {

--- a/Extensions/Content/Dnn.PersonaBar.Pages/admin/personaBar/App_LocalResources/Pages.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/admin/personaBar/App_LocalResources/Pages.resx
@@ -702,6 +702,9 @@
   <data name="NeutralPageClickButton.Text" xml:space="preserve">
     <value>To change this to a translatable page, click the button here.</value>
   </data>
+  <data name="Shared.Text" xml:space="preserve">
+    <value>Shared</value>
+  </data>
   <data name="NotifyModalHeader.Text" xml:space="preserve">
     <value>Send a notification to translators</value>
   </data>

--- a/Extensions/Content/Dnn.PersonaBar.Pages/admin/personaBar/App_LocalResources/Pages.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/admin/personaBar/App_LocalResources/Pages.resx
@@ -702,8 +702,11 @@
   <data name="NeutralPageClickButton.Text" xml:space="preserve">
     <value>To change this to a translatable page, click the button here.</value>
   </data>
-  <data name="Shared.Text" xml:space="preserve">
-    <value>Shared</value>
+  <data name="SharedModule.Text" xml:space="preserve">
+    <value>Shared: true</value>
+  </data>
+  <data name="IsNotSharedModule.Text" xml:space="preserve">
+    <value>Shared: false</value>
   </data>
   <data name="NotifyModalHeader.Text" xml:space="preserve">
     <value>Send a notification to translators</value>


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/151

Clicking on an `Update localization`, application removes all modules for which `IsLocalized` property has been changed. Instead, system starts using reference to an original version of a module. Shared module is not getting re-published automatically, so it gets invisible in a view mode. As per customers, this is expected behavior as content of referenced module can be different.
Now users are confused when particular page settings are modified, but changes are applied to all other pages. This is because of shared module.
Customer don't want to have an effect globally and localization of a shared module property should be handled better, ideally, on a module level settings and not on a page settings. 
So, request is to add tooltip info whether module is shared or not and gray out (disable) the chain icon for a shared modules. 