### PR TITLE
SEO: URL Regex: Settings are saved in HostSettings but pull…

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
@@ -244,9 +244,8 @@ namespace Dnn.PersonaBar.Seo.Services
                 {
                     // if no errors, update settings in db
                     UpdateRegexSettingsInternal(request);
-                    DataCache.ClearHostCache(false);
-                    CacheController.FlushPageIndexFromCache();
-                    CacheController.FlushFriendlyUrlSettingsFromCache();
+                    // clear cache
+                    ClearCache();
 
                     return Request.CreateResponse(HttpStatusCode.OK, new { Success = true });
                 }
@@ -274,15 +273,29 @@ namespace Dnn.PersonaBar.Seo.Services
 
             settings.ToList().ForEach((value) =>
             {
-                if (PortalId > -1)
+                if (PortalId == Null.NullInteger)
                 {
-                    PortalController.Instance.UpdatePortalSetting(PortalId, value.Key, value.Value, false, Null.NullString, false);
+                    HostController.Instance.Update(value.Key, value.Value, false);                    
                 }
                 else
                 {
-                    HostController.Instance.Update(value.Key, value.Value, false);
+                    PortalController.Instance.UpdatePortalSetting(PortalId, value.Key, value.Value, false, Null.NullString, false);
                 }
             });
+        }
+
+        private void ClearCache()
+        {
+            if (PortalId == Null.NullInteger)
+            {
+                DataCache.ClearHostCache(false);
+            }
+            else
+            {
+                DataCache.ClearPortalCache(PortalId, false);
+            }
+            CacheController.FlushPageIndexFromCache();
+            CacheController.FlushFriendlyUrlSettingsFromCache();
         }
 
         private static bool ValidateRegex(string regexPattern)

--- a/Extensions/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
@@ -275,7 +275,7 @@ namespace Dnn.PersonaBar.Seo.Services
             {
                 if (PortalId == Null.NullInteger)
                 {
-                    HostController.Instance.Update(value.Key, value.Value, false);                    
+                    HostController.Instance.Update(value.Key, value.Value, false);
                 }
                 else
                 {


### PR DESCRIPTION
Once SEO Regex settings are saved/updated on a portal level and page reloaded, old settings are fetched from the cache. On update, portal cache should be cleared.