### PR TITLE
Accepting spaces in search string.

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Users.Tests/SearchUsersBySearchTermTest.cs
+++ b/Extensions/Manage/Dnn.PersonaBar.Users.Tests/SearchUsersBySearchTermTest.cs
@@ -48,13 +48,14 @@ namespace Dnn.PersonaBar.Users.Tests
         [TestCase("*search**_text*", "%search_text%")]
         [TestCase("*search*%_text*", "%search_text%")]
         [TestCase("*search%_text*", "%search_text%")]
+        [TestCase("search text", "search text%")]
         public void FilteredSearchTest(string searchText, string expectedFilteredText)
         {
             int totalRecords;
             usersContract.SearchText = searchText;
             usersCtrl.GetUsers(usersContract, true, out totalRecords);
 
-            Assert.AreEqual(usersCtrl.LastSearch, expectedFilteredText);
+            Assert.AreEqual(expectedFilteredText, usersCtrl.LastSearch);
 
         }
 

--- a/Extensions/Manage/Dnn.PersonaBar.Users/Components/Helpers/SearchTextFilter.cs
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Components/Helpers/SearchTextFilter.cs
@@ -50,7 +50,7 @@ namespace Dnn.PersonaBar.Users.Components.Helpers
         {
             var pattern = new StringBuilder();
             var regexOptions = RegexOptions.IgnoreCase | RegexOptions.Compiled;
-            var inStringRegex = "^(\\*|%)?([\\w\\-_\\*\\%\\.\\@]+)(\\*|%)$";
+            var inStringRegex = "^(\\*|%)?([\\w\\-_\\s\\*\\%\\.\\@]+)(\\*|%)$";
             var regex = new Regex(inStringRegex, regexOptions);
             var matches = regex.Matches(searchText);
 
@@ -72,7 +72,7 @@ namespace Dnn.PersonaBar.Users.Components.Helpers
         {
             var regexOptions = RegexOptions.IgnoreCase | RegexOptions.Compiled;
             var pattern = new StringBuilder();
-            var prefixRegex = "^(\\*|%)?([\\w\\-_\\*\\%\\.\\@]+)";
+            var prefixRegex = "^(\\*|%)?([\\w\\-_\\s\\*\\%\\.\\@]+)";
             var regex = new Regex(prefixRegex, regexOptions);
             var matches = regex.Matches(searchText);
 
@@ -92,7 +92,7 @@ namespace Dnn.PersonaBar.Users.Components.Helpers
         {
             var pattern = new StringBuilder();
             var regexOptions = RegexOptions.IgnoreCase | RegexOptions.Compiled;
-            var suffixRegex = "([\\w\\-_\\*\\%\\.\\@]+)(\\*|%)$";
+            var suffixRegex = "([\\w\\-_\\*\\s\\%\\.\\@]+)(\\*|%)$";
             var regex = new Regex(suffixRegex, regexOptions);
             var matches = regex.Matches(searchText);
 


### PR DESCRIPTION
This PR is related to https://github.com/dnnsoftware/Dnn.AdminExperience/pull/62, and fixes the following scenario:

Given below 6 users exist:

search one
search two
search three
user one
user two
user three

When search term is **search two**, the expected result is just one record (user **search two**), but we are getting 2 results (**search two** and **user two**).

Also, searching for **two search** currently yields 3 results (**search one**, **search two** and **search three**), which makes little sense. After this change, this search returns no results.