### PR TITLE
Updates reference to ReactTabs

### DIFF
--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/Bundle.Web/src/main.jsx
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/Bundle.Web/src/main.jsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactRedux from "react-redux";
 import * as Redux from "redux";
 import ReactDOM from "react-dom";
-import ReactTabs from "react-tabs";
+import { Tabs as ReactTabs } from "react-tabs";
 import ReactCollapse from "react-collapse";
 import * as ReactCustomScrollBars from "react-custom-scrollbars";
 import ReactModal from "react-modal";


### PR DESCRIPTION
React Tabs changed from a default export to a named import, this updates the reference to it.

closes #204 