### PR TITLE
Devops: switch IgnoreExitCode to false on Yarn steps

### DIFF
--- a/Build/BuildScripts/Module.build
+++ b/Build/BuildScripts/Module.build
@@ -34,7 +34,7 @@
     <Copy SourceFiles="@(PersonaBar-css)" DestinationFolder="$(ModuleFolderName)\Css" />
   </Target>
   <Target Name="RunYarn" Condition="$(YarnWorkingDirectory.Length) > 0 AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <Yarn Command="install" WorkingDirectory="$(MSBuildProjectDirectory)\$(YarnWorkingDirectory)\" IgnoreExitCode="true"  />
-    <Yarn Command="run build" WorkingDirectory="$(MSBuildProjectDirectory)\$(YarnWorkingDirectory)\" IgnoreExitCode="true"  />
+    <Yarn Command="install" WorkingDirectory="$(MSBuildProjectDirectory)\$(YarnWorkingDirectory)\" IgnoreExitCode="false"  />
+    <Yarn Command="run build" WorkingDirectory="$(MSBuildProjectDirectory)\$(YarnWorkingDirectory)\" IgnoreExitCode="false"  />
   </Target>
 </Project>


### PR DESCRIPTION
This updates the IgnoreExitCode parameter to false on the Yarn build steps. This will catch any errors from the frontend going forward and fail our DevOps CI builds. 