### PR TITLE
Add page functionality is broken after migration to the latest react

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/App.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/App.jsx
@@ -477,7 +477,7 @@ class App extends Component {
 
     onCancelPage(parentPageId) {
         this._removePageFromTree(parentPageId);
-        this.props.changeSelectedPagePath("");
+        this.props.changeSelectedPagePath([]);
         (parentPageId !== -1) ? this.props.onCancelPage(parentPageId) : this.props.onCancelPage();
         this.setState({inDuplicateMode: false});
     }
@@ -526,7 +526,7 @@ class App extends Component {
             runUpdateStore(pageList);
 
             const onConfirm = () => {
-                this.props.changeSelectedPagePath("");
+                this.props.changeSelectedPagePath([]);
                 
                 this.props.getNewPage(parentPage).then(()=>{
                     if (parentPage && parentPage.id) {
@@ -706,7 +706,7 @@ class App extends Component {
 
         } else {
             this.onCancelPage();
-            this.props.changeSelectedPagePath("");
+            this.props.changeSelectedPagePath([]);
 
         }
     }

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Appearance/Appearance.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Appearance/Appearance.jsx
@@ -162,14 +162,14 @@ class Appearance extends Component {
                         onSelectContainer={this.onSelectContainer.bind(this) } />
                 </GridCell>
                 <GridCell>
-                    <GridCell columnSize="50">
+                    <GridCell columnSize={50}>
                         <SingleLineInputWithError style={{ width: "100%" }}
                             label={Localization.get("PageStyleSheet") }
                             tooltipMessage={Localization.get("PageStyleSheetTooltip") }
                             value={page.pageStyleSheet}
                             onChange={this.onChangePageStyleSheet.bind(this) } />
                     </GridCell>
-                    <GridCell columnSize="50">
+                    <GridCell columnSize={50}>
                         <Button type="secondary" onClick={this.previewPage.bind(this) } style={{ marginTop: "25px", float: "right" }}>
                             {Localization.get("PreviewThemeLayoutAndContainer") }
                         </Button>

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Appearance/Card/Card.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Appearance/Card/Card.jsx
@@ -55,7 +55,7 @@ class Card extends Component {
 }
 
 Card.propTypes = {
-    cardId: PropTypes.string.isRequired,
+    cardId: PropTypes.number.isRequired,
     onClick: PropTypes.func.isRequired,
     hoverText: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Seo/PageUrls/EditUrl.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/Seo/PageUrls/EditUrl.jsx
@@ -79,7 +79,7 @@ class EditUrl extends Component {
             <Collapsible accordion={true} isOpened={isOpened} keepCollapsedContent={true} className={"editUrl"}>
                 <div>
                     <GridCell>
-                        <GridCell columnSize="50" className="left-column">
+                        <GridCell columnSize={50} className="left-column">
                             <Label
                                 labelType="block"
                                 tooltipMessage={Localization.get("Pages_Seo_SiteAlias.Help")}
@@ -89,7 +89,7 @@ class EditUrl extends Component {
                                 onSelect={this.onChangeField.bind(this, "siteAlias")} 
                                 withBorder={true} />
                         </GridCell>
-                        <GridCell columnSize="50" className="right-column">
+                        <GridCell columnSize={50} className="right-column">
                             <SingleLineInputWithError
                                 style={{width: "100%"}}
                                 label={Localization.get("Pages_Seo_UrlPath")}
@@ -100,7 +100,7 @@ class EditUrl extends Component {
                     </GridCell>
                     {url.siteAlias.Key !== primaryAliasId &&
                     <GridCell>
-                        <GridCell columnSize="100">
+                        <GridCell columnSize={100}>
                             <Label
                                 labelType="block"
                                 tooltipMessage={Localization.get("Pages_Seo_SelectedAliasUsage.Help")}
@@ -112,7 +112,7 @@ class EditUrl extends Component {
                         </GridCell>
                     </GridCell>}
                     <GridCell>
-                        <GridCell columnSize="50" className="left-column">
+                        <GridCell columnSize={50} className="left-column">
                             <Label
                                 labelType="block"
                                 tooltipMessage={Localization.get("Pages_Seo_UrlType.Help")}
@@ -122,7 +122,7 @@ class EditUrl extends Component {
                                 onSelect={this.onChangeField.bind(this, "statusCode")} 
                                 withBorder={true} />
                         </GridCell>
-                        <GridCell columnSize="50" className="right-column">
+                        <GridCell columnSize={50} className="right-column">
                             {url.statusCode.Key === 301 && 
                             <SingleLineInputWithError
                                 style={{width: "100%"}}

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeParentExpand.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeParentExpand.jsx
@@ -36,22 +36,25 @@ export class PersonaBarPageTreeParentExpand extends Component {
 
     render_li() {
         const {listItems} = this.props;
-        if(listItems && listItems.length > 0)
-        return listItems.map((item)=>{
-            return (
-                <li key={item.id} className="list-item-menu">
-                    <div
-                        className={(item.selected) ? "list-item-highlight" : null}
-                        style={{height:"28px"}}>
+        if (listItems && listItems.length > 0) {
+            let index = 0;
+            return listItems.map((item) => {
+                index++;
+                return (
+                    <li key={"list-item-menu-key-" + index} className="list-item-menu">
+                        <div
+                            className={(item.selected) ? "list-item-highlight" : null}
+                            style={{height:"28px"}}>
 
-                        <div className="draft-pencil">
-                           {this.render_parentExpandButton(item)}
+                            <div className="draft-pencil">
+                            {this.render_parentExpandButton(item)}
+                            </div>
                         </div>
-                    </div>
-                    { item.childListItems && item.isOpen ? this.render_tree(item.childListItems) : null }
-                </li>
-            );
-        });
+                        { item.childListItems && item.isOpen ? this.render_tree(item.childListItems) : null }
+                    </li>
+                );
+            });
+        }
     }
 
     render() {

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
@@ -161,7 +161,7 @@ export class PersonaBarPageTreeview extends Component {
             const style = item.canManagePage ? { "whiteSpace": "nowrap", height: "28px", lineHeight: "35px", marginLeft: "15px" } : { height: "28px", marginLeft: "15px" };
             const itemNameHidden = item.status === "Hidden" ? "item-name-hidden" : "";
             return (
-                <li key={item.id} id={`list-item-${item.name}-${item.id}`}>
+                <li key={"list-item-key-" + index} id={`list-item-${item.name}-${item.id}`}>
                     <div className={item.onDragOverState && item.id !== draggedItem.id ? "dropZoneActive" : "dropZoneInactive"} >
                         {this.renderDropZone("before", item)}
                         <div
@@ -189,7 +189,7 @@ export class PersonaBarPageTreeview extends Component {
                                     (
                                         <SingleLineInput 
                                             style={{ marginBottom: "0px", width:"80%", height:"100%"}}
-                                            value={name}/>
+                                            defaultValue={name}/>
                                     ):
                                     name
                                 }


### PR DESCRIPTION
**Steps to reproduce:**
1. Log in as Super/Host user
2. Go to `Persona Bar > Manage > Pages`
3. Click on `Add Page`

**Current behavior:** 
Blank screen is displayed along with console errors.

**Expected behavior:** 
New page screen should be displayed and there should not be any console errors.

In this PR above issue is fixed.

DEMO of working `Add Page` functionality: [demo](https://drive.google.com/file/d/16OzqN6kCkux4ak3y89R7QJRKAN8bPyJw/view?usp=sharing)