### PR TITLE
Fixed #272. After selection the right file is now shown.

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/admin/personaBar/ConfigConsole.html
+++ b/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/admin/personaBar/ConfigConsole.html
@@ -12,7 +12,7 @@
             <div class="configForm">
                 <div class="form-item">
                     <div>
-                        <select data-bind="options: configs, value: config, optionsCaption: caption()" aria-label="Files"></select>
+                        <select data-bind="options: configs, value: config" aria-label="Files"></select>
                     </div>
                 </div>
                 <div class="form-item">

--- a/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/admin/personaBar/scripts/ConfigConsole.js
+++ b/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/admin/personaBar/scripts/ConfigConsole.js
@@ -10,14 +10,14 @@ All Rights Reserved
 */
 'use strict';
 define(['jquery',
-        'knockout',
-        'knockout.mapping',
-		'jquery-ui.min',
-        'main/codeEditor',
-		'main/config',
-        'jquery.easydropdown.min',
-        'dnn.jquery',
-        'main/koBindingHandlers/jScrollPane'],
+    'knockout',
+    'knockout.mapping',
+    'jquery-ui.min',
+    'main/codeEditor',
+    'main/config',
+    'jquery.easydropdown.min',
+    'dnn.jquery',
+    'main/koBindingHandlers/jScrollPane'],
     function ($, ko, koMapping, jqueryUI, codeEditor, cf) {
         var config = cf.init();
 
@@ -32,6 +32,9 @@ define(['jquery',
 
         var getConfigs = function () {
             requestService('get', 'GetConfigFilesList', {}, function (data) {
+                // add the caption as first option
+                data.Results.unshift(viewModel.resx.plConfigHelp);
+
                 viewModel.configs(data.Results);
 
                 $('.configConsolePanel select').easyDropDown({ wrapperClass: 'pb-dropdown', cutOff: 10, inFocus: true });
@@ -42,12 +45,17 @@ define(['jquery',
         }
 
         var getConfigFile = function () {
-            requestService('get', 'GetConfigFile', { 'fileName': curConfigName }, function (data) {
-                configEditor.setValue(data.FileContent);
-            }, function () {
-                // failed
-                utility.notifyError('Failed...');
-            });
+            if (curConfigName === viewModel.resx.plConfigHelp) {
+                // it's the caption, so empty the editor
+                configEditor.setValue('');
+            } else {
+                requestService('get', 'GetConfigFile', { 'fileName': curConfigName }, function (data) {
+                    configEditor.setValue(data.FileContent);
+                }, function () {
+                    // failed
+                    utility.notifyError('Failed...');
+                });
+            }
         }
 
         var saveConfigFile = function () {
@@ -86,12 +94,6 @@ define(['jquery',
                 configs: ko.observableArray([]),
                 config: ko.observable('')
             };
-
-            viewModel.caption = ko.dependentObservable(function () {
-                if (!this.config()) {
-                    return utility.resx.ConfigConsole.plConfigHelp;
-                }
-            }, viewModel);
         }
 
         var configSelectionChanged = function (data) {


### PR DESCRIPTION
Fixes #272 
After selection the right file is now shown, whereas before the right file was only shown on the first selection, but after that, the "next" file from the list opened in the editor.

## Summary
* removed the knockout binding for optionsCaption since iot did not work well with easyDropDown
* added the caption to the list of files before databinding
* checked on selection wether or not the "caption" was selected

