### PR TITLE
Added support for dialog to appear with no cancel button

### DIFF
--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
@@ -141,18 +141,17 @@ define(['jquery'], function ($) {
                         if (typeof confirmHandler === 'function') confirmHandler.apply();
                         $('#confirmation-dialog').fadeOut(200, 'linear', function () { $('#mask').hide(); });
                     });
-
-                    if (cancelBtn === undefined || cancelBtn === '') {
-                        $('#confirmation-dialog a#cancelbtn').hide();
-                    } else {
-                        var $cancelBtn = $('#confirmation-dialog a#cancelbtn');
-                        $cancelBtn.show();
-                        $cancelBtn.html(cancelBtn).unbind('click').bind('click', function () {
-                            if (typeof cancelHandler === 'function') cancelHandler.apply();
-                            $('#confirmation-dialog').fadeOut(200, 'linear', function () { $('#mask').hide(); });
-                        });
-                    }
-
+					
+					if (cancelBtn != '') {
+						$('#confirmation-dialog a#cancelbtn').show();
+						$('#confirmation-dialog a#cancelbtn').html(cancelBtn).unbind('click').bind('click', function () {
+							if (typeof cancelHandler === 'function') cancelHandler.apply();
+							$('#confirmation-dialog').fadeOut(200, 'linear', function () { $('#mask').hide(); });
+						});
+					} else {
+						$('#confirmation-dialog a#cancelbtn').hide();
+					}
+                    
                     $('#mask').show();
                     $('#confirmation-dialog').fadeIn(200, 'linear');
 
@@ -470,11 +469,6 @@ define(['jquery'], function ($) {
 });
 
 define('css', {
-    normalize: function(name, normalize) {
-        name = name.replace('main/../css/', 'cssPath/');
-        name = name.replace('main/../modules/', 'modules/');
-        return normalize(name);
-    },
     load: function (name, require, load, config) {
         function inject(filename) {
             var head = document.getElementsByTagName('head')[0];
@@ -497,7 +491,7 @@ define('css', {
             path = config.baseUrl + path;
         }
 
-        inject(path + config.urlArgs(name, path));
+        inject(path + '?' + config.urlArgs);
         load(true);
     },
     pluginBuilder: './css-build'

--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
@@ -141,10 +141,18 @@ define(['jquery'], function ($) {
                         if (typeof confirmHandler === 'function') confirmHandler.apply();
                         $('#confirmation-dialog').fadeOut(200, 'linear', function () { $('#mask').hide(); });
                     });
-                    $('#confirmation-dialog a#cancelbtn').html(cancelBtn).unbind('click').bind('click', function () {
-                        if (typeof cancelHandler === 'function') cancelHandler.apply();
-                        $('#confirmation-dialog').fadeOut(200, 'linear', function () { $('#mask').hide(); });
-                    });
+
+                    if (cancelBtn === undefined || cancelBtn === '') {
+                        $('#confirmation-dialog a#cancelbtn').hide();
+                    } else {
+                        var $cancelBtn = $('#confirmation-dialog a#cancelbtn');
+                        $cancelBtn.show();
+                        $cancelBtn.html(cancelBtn).unbind('click').bind('click', function () {
+                            if (typeof cancelHandler === 'function') cancelHandler.apply();
+                            $('#confirmation-dialog').fadeOut(200, 'linear', function () { $('#mask').hide(); });
+                        });
+                    }
+
                     $('#mask').show();
                     $('#confirmation-dialog').fadeIn(200, 'linear');
 


### PR DESCRIPTION
Closes #303 

## Summary
Added support for dialog to appear with no cancel button:

### New Code
javascript used to invoke the dialog without cancel button
```window.dnn.utility.confirm('test', 'ok')```

![image](https://user-images.githubusercontent.com/17751436/51059262-92f25980-15b9-11e9-96c3-3c062bd23ee2.png)

### Existing Feature

The old call with a cancel button still works
```window.dnn.utility.confirm('test', 'ok', 'cancel')```

![image](https://user-images.githubusercontent.com/17751436/51059326-c9c86f80-15b9-11e9-8106-352a3eb92bf9.png)


