### PR TITLE
Users module: Profile Setting is not opened after the first click

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/UserTable/EditProfile/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/UserTable/EditProfile/index.jsx
@@ -11,15 +11,15 @@ class EditProfile extends Component {
             userDetails: props.userDetails
         };
     }
-    componentWillMount() {
+    componentDidMount() {
         let {props} = this;
         if (props.userDetails === undefined || props.userDetails.userId !== props.userId) {
             this.getUserDetails(props);
         }
     }
-    componentWillReceiveProps(newProps) {
-        if (newProps.userDetails === undefined && newProps.userDetails.userId !== newProps.userId) {
-            this.getUserDetails(newProps);
+    componentDidUpdate() {
+        if (this.props.userDetails === undefined && this.props.userDetails.userId !== this.props.userId) {
+            this.getUserDetails(this.props);
         }
     }
     getUserDetails(props) {
@@ -31,9 +31,10 @@ class EditProfile extends Component {
         }));
     }
     render() {
-        return this.state.userDetails !== undefined && this.state.userDetails.editProfileUrl !== undefined  && <iframe 
+            return <iframe 
             className="edit-profile" seamless
-            src={this.state.userDetails.editProfileUrl}
+            src={this.state.userDetails !== undefined && this.state.userDetails.editProfileUrl !== undefined ? 
+                this.state.userDetails.editProfileUrl : ""}
             />;
     }
 }

--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/UserTable/UserSettings/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/UserTable/UserSettings/index.jsx
@@ -337,7 +337,7 @@ class UserSettings extends Component {
 }
 UserSettings.propTypes = {
     dispatch: PropTypes.func.isRequired,
-    userId: PropTypes.array.isRequired,
+    userId: PropTypes.number.isRequired,
     collapse: PropTypes.func.isRequired,
     userDetails: PropTypes.object,
     appSettings: PropTypes.object


### PR DESCRIPTION
**Steps to reproduce:**

1. Log in As Super User in Platform/Evoq Engage
2. Go to `Persona Bar > Manage > Users`
3. Click on `User Profile Settings` icon displayed for authorized user

**Current behavior:**

When user clicks on `Profile Settings` icon application doesn't display the section and user needs to click it again. Status of the browser shows "waiting for application url" for sometime and then nothing happens. 

**Expected behavior:**

User Profile setting section should display when user clicks on `Profile Settings` icon.