### PR TITLE
Roles module: Edit Role Group displays blank page

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/App.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/App.jsx
@@ -32,7 +32,7 @@ class Root extends Component {
     }
 }
 
-Root.PropTypes = {
+Root.propTypes = {
     dispatch: PropTypes.func.isRequired,
     selectedPage: PropTypes.number,
     selectedPageVisibleIndex: PropTypes.number

--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/FiltersBar/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/FiltersBar/index.jsx
@@ -54,11 +54,13 @@ class FiltersBar extends Component {
     }
     closeDropDown() {
         /*This is done in order to keep the dropdown closed on click on edit/delete*/
-        let {state} = this.groupsDropdownRef.current;
-        state.dropDownOpen = false;
-        this.groupsDropdownRef.current.setState({
-            state
-        });
+        let {state} = this.groupsDropdownRef;
+        if (state) {
+            state.dropDownOpen = false;
+            this.groupsDropdownRef.setState({
+                state
+            });
+        }
     }
     onSelect(option) {
         this.updateSelectedGroup(option);

--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/RoleEditor/RoleGroupEditor/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/RoleEditor/RoleGroupEditor/index.jsx
@@ -39,7 +39,7 @@ class RoleGroupEditor extends Component {
         // before the handleClick handler is called, but in spite of that, the handleClick is executed. To avoid
         // the "findDOMNode was called on an unmounted component." error we need to check if the component is mounted before execute this code
         if (!this._isMounted) { return; }
-        var node = this.node.current;
+        var node = this.rootElement !== undefined ? this.rootElement.current : null;
         if (node && !node.contains(event.target) &&
             (event.target.firstChild !== null && typeof event.target.firstChild.className === "string" && event.target.firstChild.className.indexOf("do-not-close") === -1)) {
             if (typeof this.props.onCancel === "function") {
@@ -50,7 +50,7 @@ class RoleGroupEditor extends Component {
     }
     onEditFieldChanged(name, event) {
         let {group} = this.state;
-        group[name] = event.target.value;
+        group[name] = event.target.value || "";
         this.setState({
             group
         }, () => {
@@ -101,7 +101,7 @@ class RoleGroupEditor extends Component {
     render() {
         const {props, state} = this;
         let group = Object.assign({}, state.group);
-        return props.visible && <div ref={node => this.node = node} className="role-group-editor" onClick={this.props.onClick.bind(this) }>
+        return props.visible && <div ref={node => this.rootElement = node} className="role-group-editor" onClick={this.props.onClick.bind(this) }>
             <h2>{resx.get(props.title) }</h2>
             <div className="edit-form">
                 <div className="form-items">

--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/RoleEditor/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/RoleEditor/index.jsx
@@ -193,7 +193,7 @@ class RolesEditor extends Component {
     /* eslint-disable react/no-danger */
     render() {
         let { state, props } = this;
-        const columnOne = <div className="editor-container">
+        const columnOne = <div key="editor-container-columnOne" className="editor-container">
             <div className="editor-row divider">
                 <SingleLineInputWithError
                     value={state.roleDetails.name}
@@ -250,7 +250,7 @@ class RolesEditor extends Component {
             </div>
         </div>;
 
-        const columnTwo = <div className="editor-container right-column">
+        const columnTwo = <div key="editor-container-columnTwo" className="editor-container right-column">
             <div className="editor-row divider">
                 <Label
                     label={resx.get("plRoleGroups")}

--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/RoleRow/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/src/components/roles/RoleRow/index.jsx
@@ -9,7 +9,7 @@ import util from "utils";
 let canEdit = false;
 
 const roleLabelStyle = {
-    "word-wrap": "break-word"
+    wordWrap: "break-word"
 };
 
 class RoleRow extends Component {


### PR DESCRIPTION
**Steps to reproduce:**

1. Log in As Super User
2. Navigate to Persona Bar > Manage > Roles
3. Click "Create New Role"
4. Expand Role Group drop down and select "[New Group]"
5. Provide a name and a description to the new role group and click "Save"
6. Click "Cancel"
7. Expand role groups dropdown and select the newly create role group
8. Click on the Edit Icon

**Current behavior:**

Blank screen is displayed.
Console displays below error: 
```
Uncaught TypeError: Cannot read property 'state' of undefined 
    at t.value (<anonymous>:20:57644) 
    at t.<anonymous> (<anonymous>:20:57938)
```

**Expected behavior:**

Edit Group popup should be displayed.