### PR TITLE
disableHostCheck during development

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/webpack.config.js
@@ -11,6 +11,9 @@ module.exports = {
         filename: "pages-bundle.js",
         publicPath: isProduction ? "" : "http://localhost:8080/dist/"
     },
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     module: {
         rules: [
             {

--- a/Extensions/Manage/Dnn.PersonaBar.AdminLogs/AdminLogs.Web/webpack.config.js
+++ b/Extensions/Manage/Dnn.PersonaBar.AdminLogs/AdminLogs.Web/webpack.config.js
@@ -22,7 +22,9 @@ module.exports = {
         filename: "adminLogs-bundle.js",
         publicPath: isProduction ? "" : "http://localhost:8080/dist/"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     module: {
         rules: [
             { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },

--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/webpack.config.js
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Roles.Web/webpack.config.js
@@ -13,7 +13,9 @@ module.exports = {
         filename: "roles-bundle.js",
         publicPath: isProduction ? "" : "http://localhost:8080/dist/"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     module: {
         rules: [
             { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },

--- a/Extensions/Manage/Dnn.PersonaBar.Sites/Sites.Web/webpack.config.js
+++ b/Extensions/Manage/Dnn.PersonaBar.Sites/Sites.Web/webpack.config.js
@@ -23,7 +23,9 @@ module.exports = {
         filename: moduleName + "-bundle.js",
         publicPath: isProduction ? "" : "http://localhost:8080/dist/"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     module: {
         rules: [
             { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },

--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/webpack.config.js
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/webpack.config.js
@@ -23,7 +23,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: moduleName + "-bundle.js"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/webpack.config.js
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/webpack.config.js
@@ -13,6 +13,9 @@ module.exports = {
         filename: "users-bundle.js",
         publicPath: isProduction ? "" : "http://localhost:8080/dist/"
     },
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     module: {
         rules: [
             {

--- a/Extensions/Settings/Dnn.PersonaBar.Extensions/Extensions.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.Extensions/Extensions.Web/webpack.config.js
@@ -13,7 +13,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: "extensions-bundle.js"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.Licensing/Licensing.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.Licensing/Licensing.Web/webpack.config.js
@@ -24,6 +24,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: "licensing-bundle.js",
     },
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.Prompt/Prompt.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.Prompt/Prompt.Web/webpack.config.js
@@ -18,6 +18,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8100/dist/",
         filename: 'prompt-bundle.js'
     },
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     devtool: '#source-map',
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],

--- a/Extensions/Settings/Dnn.PersonaBar.Security/Security.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/Security.Web/webpack.config.js
@@ -24,7 +24,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: "security-settings-bundle.js"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.Seo/Seo.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.Seo/Seo.Web/webpack.config.js
@@ -14,7 +14,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: "seo-bundle.js"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.Servers/Servers.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/Servers.Web/webpack.config.js
@@ -13,7 +13,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: "servers-bundle.js"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/webpack.config.js
@@ -22,7 +22,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: "siteimportexport-bundle.js"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/webpack.config.js
@@ -14,7 +14,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8085/dist/",
         filename: "site-settings-bundle.js"
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/TaskScheduler.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/TaskScheduler.Web/webpack.config.js
@@ -15,7 +15,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: 'task-scheduler-bundle.js'
     },
-
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Extensions/Settings/Dnn.PersonaBar.Vocabularies/Vocabularies.Web/webpack.config.js
+++ b/Extensions/Settings/Dnn.PersonaBar.Vocabularies/Vocabularies.Web/webpack.config.js
@@ -13,6 +13,9 @@ module.exports = {
         publicPath: isProduction ? "" : "http://localhost:8080/dist/",
         filename: moduleName + "-bundle.js"
     },
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     resolve: {
         extensions: ["*", ".js", ".json", ".jsx"],
         modules: [

--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/Bundle.Web/webpack.config.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/Bundle.Web/webpack.config.js
@@ -15,6 +15,9 @@ module.exports = {
         filename: "export-bundle.js",
         publicPath: isProduction ? "" : "http://localhost:8070/dist/"
     },
+    devServer: {
+        disableHostCheck: !isProduction
+    },
     module: {
         rules:[
             { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },


### PR DESCRIPTION
After the last update of webpack, there are a lot of errors in the browser console due to this issue https://github.com/webpack/webpack-dev-server/issues/1604

The current recommended way is to add a disableHostCheck in the devServer settings just for development. This PR implements that in all react projects but only if not build in production mode.

Closes #324 or maybe it does not and we close it manually again :)