### PR TITLE
Fixes an issue where it was impossible to edit portal aliases

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/languageSettings/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/languageSettings/index.jsx
@@ -179,7 +179,7 @@ class LanguageSettingsPanelBody extends Component {
     render() {
         const {props, state} = this;
         if (state.languageSettings) {
-            const columnOne = <div className="left-column">
+            const columnOne = <div className="left-column" key="language-settings-left-column">
                 <InputGroup>
                     <Label
                         tooltipMessage={resx.get("systemDefaultLabel.Help")}
@@ -207,7 +207,7 @@ class LanguageSettingsPanelBody extends Component {
                     />
                 </InputGroup>
             </div>;
-            const columnTwo = <div className="right-column">
+            const columnTwo = <div className="right-column" key="language-settings-right-column">
                 <InputGroup>
                     <div className="languageSettings-row_switch">
                         <Label

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/languageSettings/languageVerifier/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/languageSettings/languageVerifier/index.jsx
@@ -15,7 +15,7 @@ class LanguageVerifierPanelBody extends Component {
         super();
     }
 
-    componentDidUpdate(prevProps, prevState) {
+    componentDidUpdate(prevProps) {
         const { props } = this;
         if (prevProps.selectedPage !== props.selectedPage && props.selectedPage === 2) {
             if (props.verificationResults) {

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/languageSettings/localizedContent/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/languageSettings/localizedContent/index.jsx
@@ -156,7 +156,7 @@ LocalizedContent.propTypes = {
     closePersonaBarPage: PropTypes.func,
     languages: PropTypes.array,
     isOpen: PropTypes.bool,
-    languageSettings: PropTypes.obj,
+    languageSettings: PropTypes.object,
     portalId: PropTypes.number
 };
 

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/messageBox/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/messageBox/index.jsx
@@ -62,7 +62,7 @@ class MessageBox extends Component {
 }
 
 MessageBox.propTypes = {
-    text: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired,
     link: PropTypes.string,
     isOpened: PropTypes.bool,
     onClose: PropTypes.func.isRequired

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
@@ -183,7 +183,7 @@ class SiteAliasesPanel extends Component {
                     </div>
                     <div className="alias-items-grid">
                         {this.renderHeader()}
-                        <Collapsible isOpened={opened} style={{width: "100%", overflow: "visible" }}>
+                        <Collapsible isOpened={opened} style={{width: "100%", overflow: opened ? "visible" : "hidden"}}>
                             <SiteAliasRow
                                 alias={"-"}
                                 browser={"-"}

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
@@ -145,7 +145,7 @@ class SiteAliasesPanel extends Component {
                         browser={item.BrowserType}
                         skin={item.Skin}
                         language={item.CultureCode}
-                        isPrimary={item.IsPrimary}
+                        isPrimary={!!item.IsPrimary}
                         deletable={item.Deletable}
                         editable={item.Editable}
                         showLanguageColumn={this.props.siteAliases.Languages && this.props.siteAliases.Languages.length > 1}

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
@@ -189,7 +189,7 @@ class SiteAliasesPanel extends Component {
                                 browser={"-"}
                                 skin={"-"}
                                 language={"-"}
-                                isPrimary={"-"}
+                                isPrimary={false}
                                 deletable={false}
                                 editable={false}
                                 showLanguageColumn={this.props.siteAliases && this.props.siteAliases.Languages && this.props.siteAliases.Languages.length > 1}

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/index.jsx
@@ -12,13 +12,12 @@ import { SvgIcons } from "@dnnsoftware/dnn-react-common";
 import util from "../../../utils";
 import resx from "../../../resources";
 
-let tableFields = [];
-
 class SiteAliasesPanel extends Component {
     constructor() {
         super();
         this.state = {
-            openId: ""
+            openId: "",
+            tableFields: []
         };
     }
 
@@ -46,20 +45,25 @@ class SiteAliasesPanel extends Component {
         props.dispatch(SiteBehaviorActions.getSiteAliases(props.portalId));
     }
 
-    componentDidUpdate(props) {
-        if (tableFields.length === 0) {
-            tableFields.push({ "name": resx.get("Alias.Header"), "id": "Alias" });
-            tableFields.push({ "name": resx.get("Browser.Header"), "id": "Browser" });
-            tableFields.push({ "name": resx.get("Theme.Header"), "id": "Theme" });
-            if (props.siteAliases !== undefined && props.siteAliases. Languages.length > 1) {
-                tableFields.push({ "name": resx.get("Language.Header"), "id": "Language" });
+    componentDidUpdate(prevProps) {
+        const {props} = this;
+        if (props !== prevProps){
+            let tableFields = [];
+            if (tableFields.length === 0) {
+                tableFields.push({ "name": resx.get("Alias.Header"), "id": "Alias" });
+                tableFields.push({ "name": resx.get("Browser.Header"), "id": "Browser" });
+                tableFields.push({ "name": resx.get("Theme.Header"), "id": "Theme" });
+                if (props.siteAliases !== undefined && props.siteAliases. Languages.length > 1) {
+                    tableFields.push({ "name": resx.get("Language.Header"), "id": "Language" });
+                }
+                tableFields.push({ "name": resx.get("Primary.Header"), "id": "Primary" });
             }
-            tableFields.push({ "name": resx.get("Primary.Header"), "id": "Primary" });
+            this.setState({tableFields});
         }
     }
 
     renderHeader() {
-        let tableHeaders = tableFields.map((field) => {
+        let tableHeaders = this.state.tableFields.map((field) => {
             let className = "alias-items header-" + field.id;
             return <div className={className} key={"header-" + field.id}>
                 <span>{field.name}&nbsp; </span>

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/siteAliasEditor/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/siteAliasSettings/siteAliases/siteAliasEditor/index.jsx
@@ -35,6 +35,24 @@ class SiteAliasEditor extends Component {
         }
     }
 
+    componentDidUpdate(prevProps){
+        const {props, state} = this;
+        if ((props !== prevProps) && props.aliasDetail ){
+            if (props.aliasDetail["HTTPAlias"] === undefined || props.aliasDetail["HTTPAlias"] === "") {
+                state.error["alias"] = true;
+            }
+            else if (props.aliasDetail["HTTPAlias"] !== "" && props.aliasDetail["HTTPAlias"] !== undefined) {
+                state.error["alias"] = false;
+            }
+    
+            this.setState({
+                aliasDetail: Object.assign({}, props.aliasDetail),
+                triedToSubmit: false,
+                error: state.error
+            });
+        }
+    }
+
     onSettingChange(key, event) {
         let {state, props} = this;
         let aliasDetail = Object.assign({}, state.aliasDetail);


### PR DESCRIPTION
## Summary
This is a replacement for PR #337  and closes #336 

It fixes some build warnings about invalid prop types, fixes the editing of the site aliases (the deprecated componentWillReceiveProps event was deleted and not reimplemented in any way) It also fixes a UI issue where in 9.2.2 you would see a blank row -     -     -      -  with dashes after adding or cancelling adding an alias.