### PR TITLE
Restores labels in themes

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/MiddleActions/RestoreTheme/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/MiddleActions/RestoreTheme/index.jsx
@@ -23,7 +23,7 @@ class RestoreTheme extends Component {
 
     render() {
         return (
-            <GridCell className="restore-theme" columnSize="50">
+            <GridCell className="restore-theme" columnSize={50}>
                 <Button onClick={this.restoreTheme.bind(this)}>{Localization.get("RestoreTheme")}</Button>
             </GridCell>
         );

--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/SiteTheme/ThemeFileList/ThemeFile/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/SiteTheme/ThemeFileList/ThemeFile/index.jsx
@@ -5,7 +5,7 @@ import {
     theme as ThemeActions
 } from "actions";
 import Localization from "localization";
-import { TextOverflowWrapperNew } from "@dnnsoftware/dnn-react-common";
+import { TextOverflowWrapper } from "@dnnsoftware/dnn-react-common";
 import SvgIcon from "../../../SvgIcon";
 import utils from "utils";
 import "./style.less";
@@ -125,7 +125,7 @@ class ThemeFile extends Component {
         return (
             <li className={this.getClassName() }>
                 {this.renderThumbnail() }
-                <TextOverflowWrapperNew text={props.themeFile.name} maxWidth={80} className="title" />
+                <TextOverflowWrapper text={props.themeFile.name} maxWidth={80} className="title" />
             </li>
         );
     }

--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/SiteTheme/ThemeSettings/EditThemeAttributes/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/SiteTheme/ThemeSettings/EditThemeAttributes/index.jsx
@@ -207,7 +207,7 @@ class EditThemeAttributes extends Component {
                     <div>
                         <h3>{Localization.get("EditThemeAttributes")}</h3>
                         <GridCell>
-                            <GridCell columnSize="50">
+                            <GridCell columnSize={50}>
                                 <DropdownWithError
                                     defaultDropdownValue={Localization.get("NoneSpecified")}
                                     options={this.getThemeOptions()}
@@ -217,7 +217,7 @@ class EditThemeAttributes extends Component {
                                     error={state.startSave && !state.themeName}
                                     label={Localization.get("Theme")} />
                             </GridCell>
-                            <GridCell columnSize="50" className="right-column">
+                            <GridCell columnSize={50} className="right-column">
                                 <RadioButtons
                                     options={[{ value: "layout", label: Localization.get("Layout") }, { value: "container", label: Localization.get("Container") }]}
                                     onChange={this.onThemeTypeChanged.bind(this)}
@@ -225,7 +225,7 @@ class EditThemeAttributes extends Component {
                                     float="none" />
                             </GridCell>
                             <div className="clear split" />
-                            <GridCell columnSize="50">
+                            <GridCell columnSize={50}>
                                 <DropdownWithError
                                     defaultDropdownValue={Localization.get("NoneSpecified")}
                                     options={this.getThemeFileOptions()}
@@ -236,7 +236,7 @@ class EditThemeAttributes extends Component {
                                     error={state.startSave && !state.path}
                                     label={Localization.get("File")} />
                             </GridCell>
-                            <GridCell columnSize="50" className="right-column">
+                            <GridCell columnSize={50} className="right-column">
                                 <DropdownWithError
                                     defaultDropdownValue={Localization.get("NoneSpecified")}
                                     options={this.getSettingOptions()}
@@ -247,7 +247,7 @@ class EditThemeAttributes extends Component {
                                     error={state.startSave && !state.setting}
                                     label={Localization.get("Setting")} />
                             </GridCell>
-                            <GridCell columnSize="50">
+                            <GridCell columnSize={50}>
                                 <DropdownWithError
                                     defaultDropdownValue={Localization.get("NoneSpecified")}
                                     options={this.getTokenOptions()}
@@ -258,10 +258,10 @@ class EditThemeAttributes extends Component {
                                     error={state.startSave && !state.token}
                                     label={Localization.get("Token")} />
                             </GridCell>
-                            <GridCell columnSize="50" className="right-column">
+                            <GridCell columnSize={50} className="right-column">
                                 {this.renderValueField()}
                             </GridCell>
-                            <GridCell columnSize="100" className="actions-cell">
+                            <GridCell columnSize={100} className="actions-cell">
                                 <Button onClick={this.cancelEdit.bind(this)}>{Localization.get("Cancel")}</Button>
                                 <Button type="primary" onClick={this.Save.bind(this)}>{Localization.get("Apply")}</Button>
                             </GridCell>

--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/ThemeList/Theme/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/ThemeList/Theme/index.jsx
@@ -5,7 +5,7 @@ import {
     theme as ThemeActions
 } from "actions";
 import Localization from "localization";
-import { TextOverflowWrapperNew } from "@dnnsoftware/dnn-react-common";
+import { TextOverflowWrapper } from "@dnnsoftware/dnn-react-common";
 import SvgIcon from "../../SvgIcon";
 import utils from "utils";
 import "./style.less";
@@ -106,7 +106,7 @@ class Theme extends Component {
         return (
             <div className={this.getClassName() }>
                 {this.renderThumbnail() }
-                <TextOverflowWrapperNew text={props.theme.packageName} maxWidth={168} className="title" />
+                <TextOverflowWrapper text={props.theme.packageName} maxWidth={168} className="title" />
             </div>
         );
     }

--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/ThemeList/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Themes.Web/src/components/Body/ThemeList/index.jsx
@@ -38,7 +38,7 @@ class ThemeList extends Component {
                             autoHeightMax={480}>
                             <GridCell>
                                 {globalThemes.map((theme, i) => {
-                                    return <GridCell key={i} columnSize="25"><Theme theme={theme} /></GridCell>;
+                                    return <GridCell key={i} columnSize={25}><Theme theme={theme} /></GridCell>;
                                 })}
                             </GridCell>
                         </Scrollbars>
@@ -57,7 +57,7 @@ class ThemeList extends Component {
                             autoHeightMax={480}>
                             <GridCell>
                                 {siteThemes.map((theme, i) => {
-                                    return <GridCell key={i} columnSize="25"><Theme theme={theme} /></GridCell>;
+                                    return <GridCell key={i} columnSize={25}><Theme theme={theme} /></GridCell>;
                                 })}
                             </GridCell>
                         </Scrollbars>


### PR DESCRIPTION
## Summary
Fixed some column sizes passed as strings instead of numbers.
Replaced TextOverflowWrapperNew by TextOverflowWrapper, the props in place where for the normal one not the new one.

Closes #340 