### PR TITLE
Settings > Site Settings > Languages > Activate Pages Toggle not working

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/translatePageContent/translatePageContent.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/translatePageContent/translatePageContent.jsx
@@ -14,19 +14,18 @@ import utils from "utils";
 
 
 class TranslatePageContent extends Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {
             pageList: [],
             basicSettings: null,
-            languageBeingEdited: null
-        };
-        this.getProgressData = this.getProgressData.bind(this);
+            languageBeingEdited: Object.assign({}, props.languageBeingEdited)
+        };       
+        this.init(); 
     }
 
-    componentDidMount() {
-        const {props} = this;
-        this.setState({ languageBeingEdited: Object.assign({}, props.languageBeingEdited) });
+    init() {        
+        this.getProgressData = this.getProgressData.bind(this);
         this.getPageList();
         this.getBasicSettings();
         this.getProgressData();
@@ -230,7 +229,7 @@ class TranslatePageContent extends Component {
                             <Switch
                                 onText={resx.get("SwitchOn")}
                                 offText={resx.get("SwitchOff")}
-                                value={languageBeingEdited.Active}
+                                value={state.languageBeingEdited.Active}
                                 readOnly={!isEnabled}
                                 onChange={this.onToggleActive.bind(this) }
                             />

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/translatePageContent/translatePageContent.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/SiteSettings.Web/src/components/translatePageContent/translatePageContent.jsx
@@ -20,7 +20,7 @@ class TranslatePageContent extends Component {
             pageList: [],
             basicSettings: null,
             languageBeingEdited: Object.assign({}, props.languageBeingEdited)
-        };       
+        };
         this.init(); 
     }
 


### PR DESCRIPTION
fixes #348 

## Summary
- Remove wrong react hook componentDidMount with constructor as earlier it was componentWillMount
- Use state to render the switch
