### PR TITLE
DNN Products > Persona Bar > Pages > Page name displays blank in Edit mode

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageDetailsFooter/PageDetailsFooter.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/PageDetails/PageDetailsFooter/PageDetailsFooter.jsx
@@ -36,7 +36,9 @@ class PageDetailsFooter extends Component {
                 onChangeIncludeInMenu={this.onChangeValue.bind(this,"includeInMenu")} />];
             if (includeTemplates && page.tabId === 0) {
                 defaultLeftColumnComponents.push(
-                    <Template templates={page.templates} 
+                    <Template 
+                        key={"templateKey-" + page.tabId}
+                        templates={page.templates} 
                         selectedTemplateId={page.templateId}
                         onSelect={this.onChangeField.bind(this, "templateId")} />
                 );

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
@@ -189,7 +189,8 @@ export class PersonaBarPageTreeview extends Component {
                                     (
                                         <SingleLineInput 
                                             style={{ marginBottom: "0px", width:"80%", height:"100%"}}
-                                            defaultValue={name}/>
+                                            onChange={() => void(0)}
+                                            value={name}/>
                                     ):
                                     name
                                 }


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/308

I found we changed `value` to non-existent `defaultValue` property in some of previous commits. I changed it back and added fake `onChange` event to avoid react warnings saying that `onChange` is mandatory when `value` is defined. I have also corrected one warning related to `key` attribute. 

See [DEMO](https://drive.google.com/file/d/1u4-IyHQZa1ceoRQKcAsJf9xfGpEsAjzy/view?usp=sharing)