### PR TITLE
Tags-input.css path was not correct

### DIFF
--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/koBindingHandlers/tagsInput.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/koBindingHandlers/tagsInput.js
@@ -3,7 +3,7 @@ define([
         'jquery',
         'knockout',
         'dnn.jquery',
-        'css!main/../css/tags-input.css'
+        'css!cssPath/tags-input.css'
 ],
 
 function($, ko) {


### PR DESCRIPTION
Fixes #398 

## Summary
Correct path in tagsinput.js be using cssPath variable
