### PR TITLE
DNN Platform RC2 > Users> Add User throwing error messages

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/CreateUserBox/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/CreateUserBox/index.jsx
@@ -47,11 +47,9 @@ class CreateUserBox extends Component {
 
     onChangePassword(event) {
         this.setState({
-            UserDetails:{
-                password: event.target.value
-            },
-            errors:{password:false}
-        }); 
+            UserDetails: Object.assign(this.state.UserDetails, {password : event.target.value}),
+            errors: Object.assign(this.state.errors, {password:false})
+        });
     }
 
     onChange(key, item) {
@@ -306,4 +304,4 @@ const mapDispatchToProps = (dispatch) => {
     };
 };
 
-export default connect(()=>{},mapDispatchToProps)(CreateUserBox);
+export default connect(() => { return {}; },mapDispatchToProps)(CreateUserBox);

--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/common/Password/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/common/Password/index.jsx
@@ -44,7 +44,7 @@ Password.propTypes = {
     error:PropTypes.object,
     style: PropTypes.object.isRequired,
     UserDetails: PropTypes.object.isRequired,
-    requiresQuestionAndAnswer : PropTypes.bool.isRequired,
+    requiresQuestionAndAnswer : PropTypes.bool,
     onChangePassword : PropTypes.func.isRequired,
     passwordStrengthOptions : PropTypes.object,
     loadPasswordStrengthOptions : PropTypes.func


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/420

Rootcause:
There is a regression found in https://github.com/dnnsoftware/Dnn.AdminExperience/pull/406
After that fix, on password change, `userDetails` object gets completely cleared, so only `password` property gets assigned to it. This leads to incorrect behavior when rendering and validating fields on a save.

To satisfy both browsers chrome and edge, I did a small correction to keep `UserDetails` refreshed only with a new password value. All other properties remains unchanged.

See short demo (tested on chrome and edge) : [demo](https://drive.google.com/file/d/1O629Q5p2MrlyoP966mDPlYCdvgG4evun/view?usp=sharing)