### PR TITLE
Transpile arrow functions in UsersCommon.js

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/webpack.config.js
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     module: {
         rules: [
             { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },
-            { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: "babel-loader" },
+            { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: "babel-loader", options: { presets: ['@babel/preset-env'] } },
             { test: /\.(less|css)$/, loader: ["style-loader","css-loader","less-loader"] },
             { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
             { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },


### PR DESCRIPTION
This fixes the first of two IE 11 compatibility issues in the Users extension.

I don't have any idea why the `.babelrc` file is being ignored, but moving the `@babel/preset-env` reference into `webpack.config.js` caused the arrow functions to get transpiled away.

For #390 

