### PR TITLE
Settings > Scheduler > Add task UI issue in IE11

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/TaskScheduler.Web/src/components/scheduler/index.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/TaskScheduler.Web/src/components/scheduler/index.jsx
@@ -196,7 +196,7 @@ class SchedulerPanel extends Component {
                     </div>
                     <div className="schedule-items-grid">
                         {this.renderHeader()}
-                        <Collapsible isOpened={opened} style={{ float: "left" }} fixedHeight={650}>
+                        <Collapsible isOpened={opened} style={{ float: "left", width: "100%" }} fixedHeight={650}>
                             <SchedulerRow
                                 name={"-"}
                                 frequency={"-"}


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/429

To fix flex IE issue it's enough to set width to the parent element. Works good in all browsers.

IE11 and Edge:

![image](https://user-images.githubusercontent.com/22524011/54284882-7c608280-45a9-11e9-87d8-335a390916df.png)

![image](https://user-images.githubusercontent.com/22524011/54284900-81bdcd00-45a9-11e9-9324-63b5a539320c.png)


