### PR TITLE
update version to v2.0.0

### DIFF
--- a/Build/Symbols/Symbols.dnn
+++ b/Build/Symbols/Symbols.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.UI_Symbols" type="Library" version="01.06.01">
+    <package name="Dnn.PersonaBar.UI_Symbols" type="Library" version="02.00.00">
       <friendlyName>DotNetNuke Dnn.PersonaBar.UI Symbols</friendlyName>
       <description>This package contains Debug Symbols and Intellisense files for DotNetNuke Dnn.PersonaBar.UI Edition.</description>
       <owner>

--- a/EditBar/Build/Symbols/Symbols.dnn
+++ b/EditBar/Build/Symbols/Symbols.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.EditBar.UI_Symbols" type="Library" version="01.06.01">
+    <package name="Dnn.EditBar.UI_Symbols" type="Library" version="02.00.00">
       <friendlyName>DotNetNuke Dnn.EditBar.UI Symbols</friendlyName>
       <description>This package contains Debug Symbols and Intellisense files for DotNetNuke Dnn.EditBar.UI package(s).</description>
       <owner>

--- a/EditBar/Dnn.EditBar.UI/Dnn.EditBar.UI.dnn
+++ b/EditBar/Dnn.EditBar.UI/Dnn.EditBar.UI.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.EditBar.UI" type="Library" version="01.06.01">
+        <package name="Dnn.EditBar.UI" type="Library" version="02.00.00">
             <friendlyName>Dnn.EditBar.UI</friendlyName>
             <description></description>
             <dependencies/>

--- a/EditBar/SolutionInfo.cs
+++ b/EditBar/SolutionInfo.cs
@@ -44,5 +44,5 @@ using System.Reflection;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.6.1.0")]
-[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/Extensions/Build/Symbols/Symbols.dnn
+++ b/Extensions/Build/Symbols/Symbols.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Extensions_Symbols" type="Library" version="01.06.01">
+    <package name="Dnn.PersonaBar.Extensions_Symbols" type="Library" version="02.00.00">
       <friendlyName>DotNetNuke Dnn.PersonaBar.Extensions Symbols</friendlyName>
       <description>This package contains Debug Symbols and Intellisense files for DotNetNuke Dnn.PersonaBar.Extensions Edition.</description>
       <owner>

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Dnn.PersonaBar.Pages.dnn
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Dnn.PersonaBar.Pages.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.Pages" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.Pages" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.Pages</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Content/Dnn.PersonaBar.Recyclebin/Dnn.PersonaBar.Recyclebin.dnn
+++ b/Extensions/Content/Dnn.PersonaBar.Recyclebin/Dnn.PersonaBar.Recyclebin.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Recyclebin" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.Recyclebin" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.Recyclebin</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Manage/Dnn.PersonaBar.AdminLogs/Dnn.PersonaBar.AdminLogs.dnn
+++ b/Extensions/Manage/Dnn.PersonaBar.AdminLogs/Dnn.PersonaBar.AdminLogs.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.AdminLogs" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.AdminLogs" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.AdminLogs</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Dnn.PersonaBar.Roles.dnn
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Dnn.PersonaBar.Roles.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.Roles" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.Roles" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.Roles</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Manage/Dnn.PersonaBar.Sites/Dnn.PersonaBar.Sites.dnn
+++ b/Extensions/Manage/Dnn.PersonaBar.Sites/Dnn.PersonaBar.Sites.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.Sites" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.Sites" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.Sites</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Dnn.PersonaBar.Themes.dnn
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Dnn.PersonaBar.Themes.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.Themes" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.Themes" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.Themes</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Manage/Dnn.PersonaBar.Users/Dnn.PersonaBar.Users.dnn
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Dnn.PersonaBar.Users.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Users" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.Users" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.Users</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/Dnn.PersonaBar.ConfigConsole.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/Dnn.PersonaBar.ConfigConsole.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.ConfigConsole" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.ConfigConsole" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.ConfigConsole</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Connectors/Dnn.PersonaBar.Connectors.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Connectors/Dnn.PersonaBar.Connectors.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.Connectors" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.Connectors" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.Connectors</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.CssEditor/Dnn.PersonaBar.CssEditor.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.CssEditor/Dnn.PersonaBar.CssEditor.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.CssEditor" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.CssEditor" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.CssEditor</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Extensions" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.Extensions" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.Extensions</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Licensing/Dnn.PersonaBar.Licensing.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Licensing/Dnn.PersonaBar.Licensing.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.Licensing" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.Licensing" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.Licensing</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Prompt/Dnn.PersonaBar.Prompt.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Prompt/Dnn.PersonaBar.Prompt.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Prompt" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.Prompt" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.Prompt</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.SearchSettings/Dnn.PersonaBar.SearchSettings.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.SearchSettings/Dnn.PersonaBar.SearchSettings.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.SearchSettings" type="Module" version="01.06.01">
+        <package name="Dnn.PersonaBar.SearchSettings" type="Module" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.SearchSettings</friendlyName>
             <description></description>
             <iconFile>images/module_icon_32x32.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Security/Dnn.PersonaBar.Security.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/Dnn.PersonaBar.Security.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Security" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.Security" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.Security</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Seo/Dnn.PersonaBar.Seo.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Seo/Dnn.PersonaBar.Seo.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Seo" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.Seo" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.Seo</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Servers/Dnn.PersonaBar.Servers.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/Dnn.PersonaBar.Servers.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.Servers" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.Servers" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.Servers</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/Dnn.PersonaBar.SiteImportExport.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/Dnn.PersonaBar.SiteImportExport.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.SiteImportExport" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.SiteImportExport" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.SiteImportExport</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/Dnn.PersonaBar.SiteSettings.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/Dnn.PersonaBar.SiteSettings.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.SiteSettings" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.SiteSettings" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.SiteSettings</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.SqlConsole/Dnn.PersonaBar.SqlConsole.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.SqlConsole/Dnn.PersonaBar.SqlConsole.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.SqlConsole" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.SqlConsole" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.SqlConsole</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/Dnn.PersonaBar.TaskScheduler.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/Dnn.PersonaBar.TaskScheduler.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.TaskScheduler" type="PersonaBar" version="01.06.01">
+        <package name="Dnn.PersonaBar.TaskScheduler" type="PersonaBar" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.TaskScheduler</friendlyName>
             <description></description>
             <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Extensions/Settings/Dnn.PersonaBar.Vocabularies/Dnn.PersonaBar.Vocabularies.dnn
+++ b/Extensions/Settings/Dnn.PersonaBar.Vocabularies/Dnn.PersonaBar.Vocabularies.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Vocabularies" type="PersonaBar" version="01.06.01">
+    <package name="Dnn.PersonaBar.Vocabularies" type="PersonaBar" version="02.00.00">
       <friendlyName>Dnn.PersonaBar.Vocabularies</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>

--- a/Library/Dnn.PersonaBar.UI/Dnn.PersonaBar.UI.dnn
+++ b/Library/Dnn.PersonaBar.UI/Dnn.PersonaBar.UI.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
     <packages>
-        <package name="Dnn.PersonaBar.UI" type="Library" version="01.06.01">
+        <package name="Dnn.PersonaBar.UI" type="Library" version="02.00.00">
             <friendlyName>Dnn.PersonaBar.UI</friendlyName>
             <description></description>
             <dependencies/>

--- a/SolutionInfo.cs
+++ b/SolutionInfo.cs
@@ -44,5 +44,5 @@ using System.Reflection;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.6.1.0")]
-[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]


### PR DESCRIPTION
Prior to v9.3.0, DevOps was setting both platform and AE versions at build time. Starting with v9.3.0 we switched to using GitVersion on platform. However, since we haven't yet configured GitVersion on AE the code in our DevOps task wasn't updating the version correctly.

This PR updates the various versions to their correct value. For v9.3.1/v9.4.0 we should have GitVersion wired up in AE so this won't need to be manually updated for future releases. 