### PR TITLE
Upgrade to .NET Framework 4.7.2

### DIFF
--- a/EditBar/Dnn.EditBar.Library/Dnn.EditBar.Library.csproj
+++ b/EditBar/Dnn.EditBar.Library/Dnn.EditBar.Library.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.EditBar.Library</RootNamespace>
     <AssemblyName>Dnn.EditBar.Library</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/EditBar/Dnn.EditBar.UI/Dnn.EditBar.UI.csproj
+++ b/EditBar/Dnn.EditBar.UI/Dnn.EditBar.UI.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Dnn.EditBar.UI</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <OptionInfer>On</OptionInfer>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Extensions/Content/Dnn.PersonaBar.Pages.Tests/Dnn.PersonaBar.Pages.Tests.csproj
+++ b/Extensions/Content/Dnn.PersonaBar.Pages.Tests/Dnn.PersonaBar.Pages.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Pages.Tests</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Pages.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Extensions/Content/Dnn.PersonaBar.Pages/Dnn.PersonaBar.Pages.csproj
+++ b/Extensions/Content/Dnn.PersonaBar.Pages/Dnn.PersonaBar.Pages.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Pages</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Pages</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Content/Dnn.PersonaBar.Recyclebin/Dnn.PersonaBar.Recyclebin.csproj
+++ b/Extensions/Content/Dnn.PersonaBar.Recyclebin/Dnn.PersonaBar.Recyclebin.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Recyclebin</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Recyclebin</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Manage/Dnn.PersonaBar.AdminLogs/Dnn.PersonaBar.AdminLogs.csproj
+++ b/Extensions/Manage/Dnn.PersonaBar.AdminLogs/Dnn.PersonaBar.AdminLogs.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.AdminLogs</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.AdminLogs</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Manage/Dnn.PersonaBar.Roles/Dnn.PersonaBar.Roles.csproj
+++ b/Extensions/Manage/Dnn.PersonaBar.Roles/Dnn.PersonaBar.Roles.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Roles</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Roles</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Manage/Dnn.PersonaBar.Sites/Dnn.PersonaBar.Sites.csproj
+++ b/Extensions/Manage/Dnn.PersonaBar.Sites/Dnn.PersonaBar.Sites.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Sites</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Sites</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Manage/Dnn.PersonaBar.Themes/Dnn.PersonaBar.Themes.csproj
+++ b/Extensions/Manage/Dnn.PersonaBar.Themes/Dnn.PersonaBar.Themes.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Themes</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Themes</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Manage/Dnn.PersonaBar.Users.Tests/Dnn.PersonaBar.Users.Tests.csproj
+++ b/Extensions/Manage/Dnn.PersonaBar.Users.Tests/Dnn.PersonaBar.Users.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Users.Tests</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Users.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Extensions/Manage/Dnn.PersonaBar.Users/Dnn.PersonaBar.Users.csproj
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Dnn.PersonaBar.Users.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Users</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Users</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/Dnn.PersonaBar.ConfigConsole.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.ConfigConsole/Dnn.PersonaBar.ConfigConsole.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.ConfigConsole</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.ConfigConsole</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Connectors/Dnn.PersonaBar.Connectors.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Connectors/Dnn.PersonaBar.Connectors.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Connectors</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Connectors</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.CssEditor/Dnn.PersonaBar.CssEditor.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.CssEditor/Dnn.PersonaBar.CssEditor.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.CssEditor</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.CssEditor</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Extensions/Dnn.PersonaBar.Extensions.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Extensions</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Extensions</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Licensing/Dnn.PersonaBar.Licensing.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Licensing/Dnn.PersonaBar.Licensing.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Licensing</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Licensing</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Prompt/Dnn.PersonaBar.Prompt.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Prompt/Dnn.PersonaBar.Prompt.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Prompt</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Prompt</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.SearchSettings/Dnn.PersonaBar.SearchSettings.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.SearchSettings/Dnn.PersonaBar.SearchSettings.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.SearchSettings</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.SearchSettings</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Security.Tests/Dnn.PersonaBar.Security.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Security.Tests</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Security.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Extensions/Settings/Dnn.PersonaBar.Security/Dnn.PersonaBar.Security.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/Dnn.PersonaBar.Security.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Security</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Security</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Seo/Dnn.PersonaBar.Seo.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Seo/Dnn.PersonaBar.Seo.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Seo</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Seo</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Servers/Dnn.PersonaBar.Servers.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/Dnn.PersonaBar.Servers.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Servers</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Servers</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/Dnn.PersonaBar.SiteImportExport.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/Dnn.PersonaBar.SiteImportExport.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.SiteImportExport</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.SiteImportExport</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.SiteSettings/Dnn.PersonaBar.SiteSettings.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteSettings/Dnn.PersonaBar.SiteSettings.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.SiteSettings</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.SiteSettings</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.SqlConsole/Dnn.PersonaBar.SqlConsole.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.SqlConsole/Dnn.PersonaBar.SqlConsole.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.SqlConsole</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.SqlConsole</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/Dnn.PersonaBar.TaskScheduler.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.TaskScheduler/Dnn.PersonaBar.TaskScheduler.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.TaskScheduler</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.TaskScheduler</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Extensions/Settings/Dnn.PersonaBar.Vocabularies/Dnn.PersonaBar.Vocabularies.csproj
+++ b/Extensions/Settings/Dnn.PersonaBar.Vocabularies/Dnn.PersonaBar.Vocabularies.csproj
@@ -14,7 +14,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Vocabularies</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Vocabularies</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />

--- a/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
+++ b/Library/Dnn.PersonaBar.Library/Dnn.PersonaBar.Library.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dnn.PersonaBar.Library</RootNamespace>
     <AssemblyName>Dnn.PersonaBar.Library</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Library/Dnn.PersonaBar.UI/Dnn.PersonaBar.UI.csproj
+++ b/Library/Dnn.PersonaBar.UI/Dnn.PersonaBar.UI.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Dnn.PersonaBar.UI</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <OptionInfer>On</OptionInfer>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/NuGetPackages/NuGetPackages.csproj
+++ b/NuGetPackages/NuGetPackages.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Yarn.MSBuild.1.7.0\build\Yarn.MSBuild.props" Condition="Exists('..\packages\Yarn.MSBuild.1.7.0\build\Yarn.MSBuild.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGetPackages</RootNamespace>
     <AssemblyName>NuGetPackages</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>

--- a/NuGetPackages/app.config
+++ b/NuGetPackages/app.config
@@ -1,43 +1,43 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0" />
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.3.13283" newVersion="2.6.3.13283" />
+        <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.6.3.13283" newVersion="2.6.3.13283"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.8.1.0" newVersion="1.8.1.0" />
+        <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.8.1.0" newVersion="1.8.1.0"/>
       </dependentAssembly>     
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http.WebHost" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Http.WebHost" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="HtmlAgilityPack" publicKeyToken="bd319b19eaf3b43a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.9.0" newVersion="1.4.9.0" />
+        <assemblyIdentity name="HtmlAgilityPack" publicKeyToken="bd319b19eaf3b43a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.4.9.0" newVersion="1.4.9.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>


### PR DESCRIPTION
## Summary
Upgraded all projects to use .NET Framework 4.7.2, since Platform was updated this has been an issue building the v9.4 branches. 

Related to https://github.com/dnnsoftware/Dnn.Platform/pull/2644 
