### PR TITLE
- Unable to add module from Disabled page

### DIFF
--- a/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ExistingModuleDialog.js
+++ b/EditBar/Dnn.EditBar.UI/editBar/resources/ContentEditorManager/Js/ExistingModuleDialog.js
@@ -135,7 +135,8 @@ if (typeof dnn.ContentEditorManager === "undefined" || dnn.ContentEditorManager 
                     moduleId: '',
                     serviceRoot: 'InternalServices',
                     rootId: 'Root',
-                    parameters: { includeAllTypes: "true" }
+                    parameters: { includeAllTypes: "true" },
+                    includeDisabled: true
                 },
                 onSelectionChangedBackScript: selectPageProxyCallback
             };


### PR DESCRIPTION
Fixes [#2954](https://github.com/dnnsoftware/Dnn.Platform/issues/2594)

## Summary
- Setup the includeDisabled option