### PR TITLE
Changes biography security check for a warning

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.Security/Components/Checks/CheckBiography.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/Components/Checks/CheckBiography.cs
@@ -26,7 +26,7 @@ namespace Dnn.PersonaBar.Security.Components.Checks
                     var pd = ProfileController.GetPropertyDefinitionByName(portal.PortalID, "Biography");
                     if (pd != null && pd.DataType == richTextDataType.EntryID)
                     {
-                        result.Severity = SeverityEnum.Failure;
+                        result.Severity = SeverityEnum.Warning;
                         result.Notes.Add("Portal:" + portal.PortalName);
                     }
                 }

--- a/Extensions/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
@@ -814,7 +814,7 @@
     <value>Username</value>
   </data>
   <data name="CheckBiographyFailure.Text" xml:space="preserve">
-    <value>The field is richtext. Spammers may put links to their website in their biography field.</value>
+    <value>The field is richtext. Spammers may put links to their website in their biography field. The field type can be changed in Settings -> Site Settings -> Site Behavior -> User Profiles</value>
   </data>
   <data name="CheckBiographyReason.Text" xml:space="preserve">
     <value>The biography field is a common target for spammers as they can add links/html to it. In DNN 7.2.0 this was changed to a multiline textbox which removes this risk.</value>


### PR DESCRIPTION
Closes #98 

## Summary
This changes the biography security check in the security analyser for a warning instead of a failure and updates the text to show where this setting can be changed. Note that with 9.3.2 this setting now defaults to plain text so in order to test, you need to change it to richtext first.

![image](https://user-images.githubusercontent.com/6371568/56075999-488b9f00-5d99-11e9-9e48-c8e952b80838.png)

