### PR TITLE
Fixes not being able to select import package with description

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/src/components/ImportModal/PackageCardOverlay.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/src/components/ImportModal/PackageCardOverlay.jsx
@@ -11,7 +11,7 @@ class PackageCardOverlay extends Component {
                 <div className="icon-container">
                     <div>{props.isSelected ? Localization.get("ClicktoDeselect") : Localization.get("ClicktoSelect")}</div>
                 </div>                
-            </div >
+            </div>
         );
     }
 }

--- a/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/src/components/ImportModal/PackagesList.jsx
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/src/components/ImportModal/PackagesList.jsx
@@ -5,24 +5,7 @@ import Localization from "localization";
 import PackageCard from "./PackageCard";
 import PackageCardOverlay from "./PackageCardOverlay";
 
-import { SvgIcons, Tooltip } from "@dnnsoftware/dnn-react-common";
-
-const tooltipStyle = {
-    style: {
-        background: "#fff",
-        color: "white",
-        padding: "10px 20px",
-        transition: "opacity 0.2s ease-in-out, visibility 0.2s ease-in-out",
-        boxShadow: "0 0 10px 1px #C8C8C8",
-        maxWidth: 500,
-        fontFamily: "'proxima_nova', 'HelveticaNeue', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-        zIndex: 9999
-    },
-    arrowStyle: {
-        color: "#fff",
-        borderColor: "#C8C8C8"
-    }
-};
+import { SvgIcons } from "@dnnsoftware/dnn-react-common";
 
 class PackagesList extends Component {
     onSelect(pkg) {
@@ -58,14 +41,16 @@ class PackagesList extends Component {
                                 isSelected={props.selectedPackage && props.selectedPackage.PackageId === pkg.PackageId} />
                             {props.selectedPackage && props.selectedPackage.PackageId === pkg.PackageId &&
                                 <div className="checkmark" dangerouslySetInnerHTML={{ __html: SvgIcons.CheckMarkIcon }}></div>
-                            }
-                            <Tooltip
-                                tooltipStyle={tooltipStyle}
-                                onClick={this.onSelect.bind(this, pkg)}
-                                messages={[this.renderTooltipMessage(pkg.Description)]}
-                                tooltipPlace="bottom"
-                            />
+                            }                            
                         </PackageCard>
+                        {
+                            pkg.Description &&
+                            <div 
+                                className="package-card-tooltip"
+                                dangerouslySetInnerHTML={{ __html : this.renderTooltipMessage(pkg.Description)}}
+                                onClick={this.onSelect.bind(this, pkg)}
+                            />
+                        }
                     </div>;
                 })}
             </div>;

--- a/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/src/components/ImportModal/style.less
+++ b/Extensions/Settings/Dnn.PersonaBar.SiteImportExport/SiteImportExport.Web/src/components/ImportModal/style.less
@@ -45,19 +45,38 @@
                     &:not(:last-child) {
                         margin-bottom: 15px;
                     }
-                    .dnn-ui-common-tooltip {
-                        position: absolute;
-                        width: 100%;
-                        height: 100%;
-                        top: 0;
-                        cursor: pointer;
-                        .icon {
-                            width: 100%;
-                            height: 100%;
-                            svg {
-                                display: none;
-                            }
-                        }                  
+                    .package-card-tooltip{
+                        background-color: #fff;
+                        position:absolute;
+                        padding: 10px 20px;
+                        background: rgb(255, 255, 255);
+                        box-shadow: rgb(200, 200, 200) 0px 0px 10px 1px;
+                        border-radius: 3px;
+                        transition: opacity 0.2s ease-in-out 0s, visibility 0.2s ease-in-out 0s;                        
+                        color: white;
+                        max-width: 500px;
+                        left: 50%;
+                        margin-left: -25%;
+                        opacity: 0;
+                        visibility: hidden;
+                        ::after{
+                            content: " ";
+                            position: absolute;
+                            bottom: 100%;
+                            left: 50%;
+                            margin-left: -10px;
+                            border-width: 10px;
+                            border-style: solid;
+                            border-color: transparent transparent white transparent;
+                        }
+                    }
+                    &:hover{
+                        .package-card-tooltip{
+                            opacity: 1;
+                            visibility: visible;
+                            z-index: 9999;
+                            cursor: pointer;
+                        }
                     }
                     .package-card {
                         text-align: left;


### PR DESCRIPTION
Closes #718 

## Summary
This PR replaces the tooltip component for a normal html/css tooltip. The tooltip component was used here but modified to not show an icon and moved and restyled. The tooltip common component was recently modified to be accessible and was mainly tested in the context of a label tooltip.
So this solution has about the same footprint without "hacking" a component that was made for label tooltips.

![image](https://user-images.githubusercontent.com/6371568/56084525-0185c400-5e02-11e9-9309-ca6303a09f80.png)
