### PR TITLE
Fixes SSL for cache sync was read from wrong value

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.Servers/Services/ServerSettingsPerformanceController.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Servers/Services/ServerSettingsPerformanceController.cs
@@ -72,7 +72,7 @@ namespace Dnn.PersonaBar.Servers.Services
                     CacheSetting = Host.PerformanceSetting,
                     AuthCacheability = Host.AuthenticatedCacheability,
                     UnauthCacheability = Host.UnauthenticatedCacheability,
-                    SslForCacheSynchronization = Host.UpgradeForceSsl,
+                    SslForCacheSynchronization = HostController.Instance.GetBoolean(UseSSLKey, false),
                     ClientResourcesManagementMode = PortalController.GetPortalSetting("ClientResourcesManagementMode", portalId, "h"),
 
                     CurrentHostVersion = Host.CrmVersion.ToString(CultureInfo.InvariantCulture),


### PR DESCRIPTION
Closes #37 

## Summary
The value for "Use SSL for Cache synchronization was being read from the wrong host setting so the value in the UI was for the wrong setting. This PR fixes it.