### PR TITLE
Ignores Biography check if deleted

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.Security/Components/Checks/CheckBiography.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/Components/Checks/CheckBiography.cs
@@ -24,7 +24,7 @@ namespace Dnn.PersonaBar.Security.Components.Checks
                 foreach (PortalInfo portal in portalController.GetPortals())
                 {
                     var pd = ProfileController.GetPropertyDefinitionByName(portal.PortalID, "Biography");
-                    if (pd != null && pd.DataType == richTextDataType.EntryID)
+                    if (pd != null && pd.DataType == richTextDataType.EntryID && !pd.Deleted)
                     {
                         result.Severity = SeverityEnum.Failure;
                         result.Notes.Add("Portal:" + portal.PortalName);

--- a/Extensions/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
@@ -820,7 +820,7 @@
     <value>The biography field is a common target for spammers as they can add links/html to it. In DNN 7.2.0 this was changed to a multiline textbox which removes this risk.</value>
   </data>
   <data name="CheckBiographySuccess.Text" xml:space="preserve">
-    <value>The field is a multiline textbox</value>
+    <value>The field not enabled or is a multiline textbox</value>
   </data>
   <data name="CheckRarelyUsedSuperuserFailure.Text" xml:space="preserve">
     <value>We have found 1 or more superuser accounts that have not been logged in or had activity in six months. Consider deleting them as a best practice</value>

--- a/Extensions/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
+++ b/Extensions/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
@@ -820,7 +820,7 @@
     <value>The biography field is a common target for spammers as they can add links/html to it. In DNN 7.2.0 this was changed to a multiline textbox which removes this risk.</value>
   </data>
   <data name="CheckBiographySuccess.Text" xml:space="preserve">
-    <value>The field not enabled or is a multiline textbox</value>
+    <value>The field is not enabled or is a multiline textbox</value>
   </data>
   <data name="CheckRarelyUsedSuperuserFailure.Text" xml:space="preserve">
     <value>We have found 1 or more superuser accounts that have not been logged in or had activity in six months. Consider deleting them as a best practice</value>


### PR DESCRIPTION
Closes #132 

## Summary
In the security analyzer, no longer reports an error on the Briography profile property being richtext if that profile property is deleted.