### PR TITLE
Fixed an issue with site map priority override

### DIFF
--- a/Extensions/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
+++ b/Extensions/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
@@ -478,7 +478,7 @@ namespace Dnn.PersonaBar.Seo.Services
                 {
                     p.Name,
                     p.Enabled,
-                    p.Priority,
+                    Priority = p.Priority / 100f,
                     p.OverridePriority
                 }).ToList();
 
@@ -518,7 +518,7 @@ namespace Dnn.PersonaBar.Seo.Services
                     editedProvider.OverridePriority = request.Priority > -1;
                     if (editedProvider.OverridePriority)
                     {
-                        editedProvider.Priority = request.Priority;
+                        editedProvider.Priority = request.Priority * 100;
                     }
                 }
 


### PR DESCRIPTION
Closes #223 

## Summary
Right or wrong, the core site map provider is coded to store the value multiplied by 100 in order to prevent errors with decimal separators in different cultures. The Persona Bar SEO module was not accounting for that fact so the values need to be multiplied and divided by 100 to save the correct value into the database and return a correct value in the UI. This PR fixes that.
