### PR TITLE
Positions password strenght label to the right

### DIFF
--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/common/Password/index.jsx
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/common/Password/index.jsx
@@ -19,7 +19,7 @@ class Password extends Component {
    
     render() {
         return (
-            <div>
+            <div className="passwordContainer">
                 <SingleLineInputWithError label={Localization.get("Password") }
                     error={this.props.error.password}
                     onChange={this.props.onChangePassword }

--- a/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/common/Password/style.less
+++ b/Extensions/Manage/Dnn.PersonaBar.Users/Users.Web/src/_exportables/src/components/common/Password/style.less
@@ -3,6 +3,9 @@
 @fair: rgb(246, 213, 0);
 @weak: red;
 
+.passwordContainer{
+    position: relative;
+}
 
 .passwordStrength {
     line-height: 1.5pt;
@@ -27,10 +30,11 @@
 }
 
 .passwordStrengthLabel {
-    position: relative;
-    top: -45px;
-    left: 308px;
+    position: absolute;
+    bottom: 30px;
+    right: 1em;
     font-weight: 700;
+    text-align: right;
 
     &.weak{
         color: @weak;


### PR DESCRIPTION
Closes #408 

## Summary
The password strenght indicator label was previously places at a specific number of pixels relative to the left of the textbox which was not responsive. On small screens it was placed out of view. This PR positions it relative to the right of the textbox so it is always at the end no mater what pane size it is in.