### PR TITLE
Add "remove deleted users" button to place you'd expect it

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Services/UsersController.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Services/UsersController.cs
@@ -374,6 +374,26 @@ namespace Dnn.PersonaBar.Users.Services
 
         [HttpPost]
         [ValidateAntiForgeryToken]
+        public HttpResponseMessage RemoveDeletedUsers()
+        {
+            if (!UserInfo.IsSuperUser)
+            {
+                if (!UserInfo.IsInRole(PortalSettings.AdministratorRoleName))
+                {
+                    return Request.CreateErrorResponse(HttpStatusCode.BadRequest, Localization.GetString("InSufficientPermissions", Components.Constants.LocalResourcesFile));
+                }
+            }
+            UserController.RemoveDeletedUsers(PortalSettings.PortalId);
+            var remaining = UserController.GetDeletedUsers(PortalSettings.PortalId);
+            if (remaining.Count > 0)
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, Localization.GetString("CouldNotRemoveAll", Components.Constants.LocalResourcesFile));
+            }
+            return Request.CreateResponse(HttpStatusCode.OK, new { Success = true });
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
         [AdvancedPermission(MenuName = Components.Constants.MenuName, Permission = Components.Constants.DeleteUser)]
         public HttpResponseMessage RestoreDeletedUser([FromUri] int userId)
         {

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/src/actions/users.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/src/actions/users.js
@@ -124,6 +124,15 @@ const userActions = {
             }, errorCallback);
         };
     },
+    removeDeletedUsers(callback) {
+        return (dispatch) => {
+            UserService.removeDeletedUsers(data => {
+                if (callback) {
+                    callback(data);
+                }
+            }, errorCallback);
+        };
+    },
     restoreUser(payload, filter, callback) {
         return (dispatch) => {
             let restoredUser = Object.assign({}, payload.userDetails);

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/src/services/users.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/src/services/users.js
@@ -57,6 +57,10 @@ class UserService {
         const sf = this.getServiceFramework("Users");
         sf.post("HardDeleteUser?" + serializeQueryStringParameters(userDetails), null, callback, errorCallback);
     }
+    removeDeletedUsers(callback, errorCallback) {
+        const sf = this.getServiceFramework("Users");
+        sf.post("RemoveDeletedUsers", null, callback, errorCallback);
+    }
     restoreUser(userDetails, callback, errorCallback) {
         const sf = this.getServiceFramework("Users");
         sf.post("RestoreDeletedUser?" + serializeQueryStringParameters(userDetails), null, callback, errorCallback);

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/components/Body/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/components/Body/index.jsx
@@ -69,6 +69,21 @@ class Body extends Component {
             </GridCell>;
     }
 
+    onRemoveDeletedUsers() {
+        utilities.confirm(
+            Localization.get("RemoveDeleted.Confirm"),
+            Localization.get("Yes"),
+            Localization.get("No"),
+            () => {
+                this.props.dispatch(CommonUsersActions.removeDeletedUsers(() => {
+                    let {searchParameters} = this.state;
+                    this.props.dispatch(CommonUsersActions.getUsers(searchParameters));
+                    utilities.notify(Localization.get("RemoveDeleted.Done"));
+                }));
+            }
+        );
+    }
+
     toggleCreateBox() {
         this.userTable.wrappedInstance.onAddUser();
     }
@@ -86,6 +101,12 @@ class Body extends Component {
                         this.canAddUser() &&  
                     <Button type="primary" size="large" onClick={this.toggleCreateBox.bind(this) } title={Localization.get("btnCreateUser")}>
                         {Localization.get("btnCreateUser") }
+                    </Button>
+                    }
+                    {
+                        appSettings.applicationSettings.settings.isAdmin &&  
+                    <Button type="secondary" size="large" onClick={() => {this.onRemoveDeletedUsers()}} title={Localization.get("RemoveDeleted.Btn")}>
+                        {Localization.get("RemoveDeleted.Btn") }
                     </Button>
                     }
                 </PersonaBarPageHeader>

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/components/Body/style.less
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/components/Body/style.less
@@ -17,6 +17,11 @@
     .user-emails, .user-joined{
         padding-left: 15px !important;
     }
+    .dnn-persona-bar-page-header {
+        button.dnn-ui-common-button {
+            margin-left: 10px;
+        }
+    }
     .dnn-persona-bar-page-body {
         &.without-margin {
             margin-top: 0;

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Users/App_LocalResources/Users.resx
@@ -1286,4 +1286,16 @@
   <data name="LastConsented.Text" xml:space="preserve">
     <value>Last consented on</value>
   </data>
+  <data name="RemoveDeleted.Btn" xml:space="preserve">
+    <value>Remove Deleted Users</value>
+  </data>
+  <data name="RemoveDeleted.Confirm" xml:space="preserve">
+    <value>Do you wish to permanently remove deleted users? You cannot undo this operation.</value>
+  </data>
+  <data name="RemoveDeleted.Done" xml:space="preserve">
+    <value>All deleted users have been removed</value>
+  </data>
+  <data name="CouldNotRemoveAll.Text" xml:space="preserve">
+    <value>Could not remove all users</value>
+  </data>
 </root>


### PR DESCRIPTION
Currently removing deleted users is handled by the "empty recycle bin" button on the recycle bin extension. This is (1) obscure and (2) not the place you'd expect to find it when managing users. On top of this you can't remove deleted users without also removing deleted pages etc. So there is also a loss of control.

In our efforts to "finish" the personabar I cannot see why we shouldn't have access to this function at the top of the users module.
