### PR TITLE
Add browserslist file

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,3 @@
+> 0.2%
+last 1 version
+not dead


### PR DESCRIPTION
Fixes #937

The chosen mix of browsers is suggested by the Browserslist tool:
>If you want to change the default set of browsers we recommend to combine `last 1 version`, `not dead` with `> 0.2%` (or `> 1% in US`, `> 1% in my stats`). `last n versions` adds too many dead browsers and does not add popular old versions. Choosing a percentage above `0.2%` will in the long run make popular browsers even more popular. We might run into a monopoly and stagnation situation, as we had with Internet Explorer 6. Please use this setting with caution.

As of today (2019-05-13), this query includes the following browsers:

>and_chr 73
>and_ff 66
>and_qq 1.2
>and_uc 11.8
>android 67
>android 4.4.3-4.4.4
>android 4.2-4.3
>baidu 7.12
>chrome 73
>chrome 72
>chrome 71
>chrome 70
>chrome 69
>chrome 63
>chrome 61
>chrome 49
>edge 18
>edge 17
>firefox 66
>firefox 65
>firefox 52
>ie 11
>ie_mob 11
>ios_saf 12.2
>ios_saf 12.0-12.1
>ios_saf 11.3-11.4
>ios_saf 11.0-11.2
>ios_saf 10.3
>kaios 2.5
>op_mini all
>op_mob 46
>opera 58
>safari 12.1
>safari 12
>safari 11.1
>safari 5.1
>samsung 9.2
>samsung 8.2
>samsung 7.2-7.4
>samsung 4