### PR TITLE
Adjust PersonaBar.UI to build after Extensions project

### DIFF
--- a/Dnn.AdminExperience.sln
+++ b/Dnn.AdminExperience.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 15.0.28307.421
 MinimumVisualStudioVersion = 15.0.28307.421
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dnn.PersonaBar.UI", "Library\Dnn.PersonaBar.UI\Dnn.PersonaBar.UI.csproj", "{7D92D57E-EB66-4816-A0FA-B39213452539}"
 	ProjectSection(ProjectDependencies) = postProject
+		{9CCA271F-CFAA-42A3-B577-7D5CBB38C646} = {9CCA271F-CFAA-42A3-B577-7D5CBB38C646}
 		{5313F690-D9A3-40B1-908C-1F5A3F3EA683} = {5313F690-D9A3-40B1-908C-1F5A3F3EA683}
 	EndProjectSection
 EndProject


### PR DESCRIPTION
## Summary
Currently, when building in the `Release` configuration, the `Dnn.PersonaBar.Extensions` project is where MSBuild is triggering the yarn workspace build process. Unfortunately `Dnn.PersonaBar.UI` depends on the output of this process. 

This PR adjusts the project dependencies and configures `Dnn.PersonaBar.UI` to depend on `Dnn.PersonaBar.Extensions`.

I ran two clean builds locally and verified the export bundle was included in the resources zip generated when compiling `Dnn.PersonaBar.UI`.