### PR TITLE
Added modules option to css-loader as per breaking change

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/AdminLogs.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/AdminLogs.Web/webpack.config.js
@@ -29,7 +29,11 @@ module.exports = {
         rules: [
             { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },
             { test: /\.(js|jsx)$/ , exclude: /node_modules/, loader: "babel-loader" },
-            { test: /\.(less|css)$/, loader: "style-loader!css-loader!less-loader" },
+            { test: /\.(less|css)$/, use: [
+                { loader: "style-loader" },
+                { loader: "css-loader", options: { modules: "global" } },
+                { loader: "less-loader" }
+            ] },
             { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
         ]
     },

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Extensions.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Extensions.Web/webpack.config.js
@@ -39,7 +39,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }] 
@@ -49,7 +50,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"
                 }, {
-                    loader: "css-loader"
+                    loader: "css-loader",
+                    options: { modules: "global"}
                 }]
             },
             { 

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Licensing.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Licensing.Web/webpack.config.js
@@ -50,7 +50,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/webpack.config.js
@@ -34,7 +34,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"
                 },{
-                    loader: "css-loader"
+                    loader: "css-loader",
+                    options: { modules: "global" }
                 },{
                     loader: "less-loader"
                 }]
@@ -44,7 +45,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"
                 },{
-                    loader: "css-loader"
+                    loader: "css-loader",
+                    options: { modules: "global"}
                 }]            
             },
             { 

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Prompt.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Prompt.Web/webpack.config.js
@@ -45,7 +45,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Roles.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Roles.Web/webpack.config.js
@@ -20,7 +20,11 @@ module.exports = {
         rules: [
             { test: /\.(js|jsx)$/, enforce: "pre", exclude: /node_modules/, loader: "eslint-loader", options: { fix: true } },
             { test: /\.(js|jsx)$/ , exclude: /node_modules/, loader: "babel-loader" },
-            { test: /\.(less|css)$/, loader: "style-loader!css-loader!less-loader" },
+            { test: /\.(less|css)$/, use: [
+                { loader: "style-loader" },
+                { loader: "css-loader", options: { modules: "global" } },
+                { loader: "less-loader" }
+            ] },
             { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
             { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
             { test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/, loader: "url-loader?mimetype=application/font-woff" },

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Security.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Security.Web/webpack.config.js
@@ -51,7 +51,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Seo.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Seo.Web/webpack.config.js
@@ -40,7 +40,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Servers.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Servers.Web/webpack.config.js
@@ -39,7 +39,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }] 

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/SiteImportExport.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/SiteImportExport.Web/webpack.config.js
@@ -51,7 +51,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/SiteSettings.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/SiteSettings.Web/webpack.config.js
@@ -48,7 +48,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Sites.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Sites.Web/webpack.config.js
@@ -38,7 +38,11 @@ module.exports = {
                     ]
                 }
             },
-            { test: /\.(less|css)$/, loader: "style-loader!css-loader!less-loader" },
+            { test: /\.(less|css)$/, use: [ 
+                { loader: "style-loader" },
+                { loader: "css-loader", options: { modules: "global" } },
+                { loader: "less-loader" }
+            ]},
             { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" }
         ]
     },

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/webpack.config.js
@@ -41,7 +41,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Themes.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Themes.Web/webpack.config.js
@@ -50,7 +50,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/webpack.config.js
@@ -27,7 +27,11 @@ module.exports = {
                     ] 
                 } 
             },
-            { test: /\.(less|css)$/, loader: ["style-loader","css-loader","less-loader"] },
+            { test: /\.(less|css)$/, use: [
+                { loader: "style-loader" },
+                { loader: "css-loader", options : { modules: "global" } },
+                { loader: "less-loader" }
+            ] },
             { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
             { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
             { test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/, loader: "url-loader?mimetype=application/font-woff" },

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/webpack.config.js
@@ -38,7 +38,11 @@ module.exports = {
                     } 
                 }
             },
-            { test: /\.(less|css)$/, loader: ["style-loader","css-loader","less-loader"] },
+            { test: /\.(less|css)$/, use: [
+                { loader: "style-loader" },
+                { loader: "css-loader", options: { modules: "global" } },
+                { loader: "less-loader" }
+            ] },
             { test: /\.(ttf|woff)$/, loader: "url-loader?limit=8192" },
             { test: /\.(gif|png)$/, loader: "url-loader?mimetype=image/png" },
             { test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/, loader: "url-loader?mimetype=application/font-woff" },

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Vocabularies.Web/webpack.config.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Vocabularies.Web/webpack.config.js
@@ -40,7 +40,8 @@ module.exports = {
                 use: [{
                     loader: "style-loader"  // creates style nodes from JS strings
                 }, {
-                    loader: "css-loader"    // translates CSS into CommonJS
+                    loader: "css-loader",    // translates CSS into CommonJS
+                    options: { modules: "global" }
                 }, {
                     loader: "less-loader"   // compiles Less to CSS
                 }]


### PR DESCRIPTION
Closes #965 

## Summary
css-loader was bumped in #926 and that version change includes a breaking change. The default used to be using global css modules but it is now an option and this defaults to false now.

This PR fixed the css problems in the persona bar by explicitelly setting the option to use global css modules manually in each webpack.config.js file of the modules that use css-loader.