### PR TITLE
Fixes css console error on PB modules

### DIFF
--- a/EditBar/Dnn.EditBar.UI/editBar/scripts/util.js
+++ b/EditBar/Dnn.EditBar.UI/editBar/scripts/util.js
@@ -166,7 +166,11 @@ define('css',{
             path = config.baseUrl + path;
         }
 
-		inject(path + '?' + config.urlArgs);
+        if (typeof config.urlArgs === 'string') {
+            path = path + '?' + config.urlArgs;
+        }
+        inject(path);
+
 		load(true);
 	},
 	pluginBuilder: './css-build'

--- a/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
+++ b/Library/Dnn.PersonaBar.UI/admin/personaBar/scripts/util.js
@@ -491,7 +491,11 @@ define('css', {
             path = config.baseUrl + path;
         }
 
-        inject(path + '?' + config.urlArgs);
+        if (typeof config.urlArgs === 'string') {
+            path = path + '?' + config.urlArgs;
+        }
+        inject(path);
+
         load(true);
     },
     pluginBuilder: './css-build'


### PR DESCRIPTION
Closes #974 

Utils.js code used to use urlArgs (provided by require.js) to append cache-busting to css files in debug mode.

Starting at some version requireJs supports either a string or a function but before it used to support only a string. So this PR first checks if urlArgs is a string, if so does the previous behavior, if not just ignores it. This is in order to try to minimize the risk if module developers have used strings here for requrests in the init function of persona bar modules.

It _should_ be no risk for third party modules using this as a string. If module developers decide to use it as a function then they can manage their own injection using that function would would not need Dnn to do it for them.