### PR TITLE
Fixed wrong path to checksums in Security Analyser

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Security/Utility.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Security/Utility.cs
@@ -156,7 +156,7 @@ namespace Dnn.PersonaBar.Security.Components
             using (
                 var stream =
                     Assembly.GetExecutingAssembly()
-                        .GetManifestResourceStream("Dnn.PersonaBar.Security.Components.Resources.sums.resources"))
+                        .GetManifestResourceStream("Dnn.PersonaBar.Extensions.Components.Security.Resources.sums.resources"))
             {
                 if (stream != null)
                 {


### PR DESCRIPTION
Closes #973 

The security analyzer was moved into the merged dll when refactoring the project and could not find the checksums with the old location. This fixes that location