### PR TITLE
Removed "show copyright credits" from PB UI.

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Services/Dto/SiteSettings/UpdatePrivacySettings.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Services/Dto/SiteSettings/UpdatePrivacySettings.cs
@@ -40,8 +40,6 @@ namespace Dnn.PersonaBar.SiteSettings.Services.Dto
 
         public bool DnnImprovementProgram { get; set; }
 
-        public bool DisplayCopyright { get; set; }
-
         public bool DataConsentActive { get; set; }
 
         public int DataConsentConsentRedirect { get; set; }

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Services/SiteSettingsController.cs
@@ -1575,8 +1575,7 @@ namespace Dnn.PersonaBar.SiteSettings.Services
                         portalSettings.ShowCookieConsent,
                         portalSettings.CookieMoreLink,
                         CheckUpgrade = HostController.Instance.GetBoolean("CheckUpgrade", true),
-                        DnnImprovementProgram = HostController.Instance.GetBoolean("DnnImprovementProgram", true),
-                        DisplayCopyright = HostController.Instance.GetBoolean("Copyright", true),
+                        DnnImprovementProgram = HostController.Instance.GetBoolean("DnnImprovementProgram", true),                        
                         portalSettings.DataConsentActive,
                         DataConsentResetTerms = false,
                         DataConsentConsentRedirect = TabSanitizer(portalSettings.DataConsentConsentRedirect, pid)?.TabID,
@@ -1617,7 +1616,6 @@ namespace Dnn.PersonaBar.SiteSettings.Services
                 PortalController.UpdatePortalSetting(pid, "CookieMoreLink", request.CookieMoreLink, false, request.CultureCode);
                 HostController.Instance.Update("CheckUpgrade", request.CheckUpgrade ? "Y" : "N", false);
                 HostController.Instance.Update("DnnImprovementProgram", request.DnnImprovementProgram ? "Y" : "N", false);
-                HostController.Instance.Update("Copyright", request.DisplayCopyright ? "Y" : "N", false);
                 PortalController.UpdatePortalSetting(pid, "DataConsentActive", request.DataConsentActive.ToString(), false);
                 PortalController.UpdatePortalSetting(pid, "DataConsentConsentRedirect", ValidateTabId(request.DataConsentConsentRedirect, pid).ToString(), false);
                 PortalController.UpdatePortalSetting(pid, "DataConsentUserDeleteAction", request.DataConsentUserDeleteAction.ToString(), false);

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/SiteSettings.Web/src/components/privacySettings/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/SiteSettings.Web/src/components/privacySettings/index.jsx
@@ -203,27 +203,7 @@ class PrivacySettingsPanelBody extends Component {
             value={state.privacySettings.CheckUpgrade}
             onChange={this.onSettingChange.bind(this, "CheckUpgrade")}
           />
-        </InputGroup>
-        <InputGroup>
-          <Label
-            labelType="inline"
-            tooltipMessage={resx.get("plDisplayCopyright.Help")}
-            label={resx.get("plDisplayCopyright")}
-            extra={
-              <Tooltip
-                messages={[resx.get("GlobalSetting")]}
-                type="global"
-                style={{ float: "left", position: "static" }}
-              />
-            }
-          />
-          <Switch
-            onText={resx.get("SwitchOn")}
-            offText={resx.get("SwitchOff")}
-            value={state.privacySettings.DisplayCopyright}
-            onChange={this.onSettingChange.bind(this, "DisplayCopyright")}
-          />
-        </InputGroup>
+        </InputGroup>        
       </div>
     ) : (
       <div key="column-one-left" className="left-column" />

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteSettings/App_LocalResources/SiteSettings.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SiteSettings/App_LocalResources/SiteSettings.resx
@@ -1362,12 +1362,6 @@
   <data name="PrivacyCookieConsentSettings.Text" xml:space="preserve">
     <value>Cookie Consent Settings</value>
   </data>
-  <data name="plDisplayCopyright.Help" xml:space="preserve">
-    <value>Include DNN Platform Copyright statement in page HTML source. Users will not see this rendered in their browser.</value>
-  </data>
-  <data name="plDisplayCopyright.Text" xml:space="preserve">
-    <value>Display Copyright</value>
-  </data>
   <data name="DataConsentActive.Help" xml:space="preserve">
     <value>When switched on, registered users will be forced to consent to the terms and conditions of this site</value>
   </data>


### PR DESCRIPTION
## Summary
This is the UI part to resolve https://github.com/dnnsoftware/Dnn.Platform/issues/2791
It removes the UI to enable or disable "show copyright credits"