### PR TITLE
() Characters that are not illegal are considered illegal characters

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/actions/pageSeoActions.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/actions/pageSeoActions.js
@@ -60,6 +60,18 @@ const pageSeoActions = {
                         data: { error: response.ErrorMessage }
                     });
                     utils.notifyError(response.ErrorMessage);
+
+                    // DNN-30998: Adding SuggestedUrl returned by the server in case of validation errors
+                    if(response.SuggestedUrlPath)
+                    {
+                        dispatch({
+                            type: ActionTypes.SEO_CHANGE_URL,
+                            payload: {
+                                key: "path",
+                                value: response.SuggestedUrlPath
+                            }
+                        });
+                    }
                     return;
                 }
 

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
@@ -523,7 +523,7 @@
     <value>{0} is an invalid Page Title.</value>
   </data>
   <data name="CustomUrlPathCleaned.Error" xml:space="preserve">
-    <value>The Page URL entered contains characters which cannot be used in a URL or are illegal characters for a URL.   These characters have been removed.  Click the Update button again to accept the modified URL.&lt;br&gt;[NOTE: The illegal characters list is the following: &lt;&gt;\?:&amp;=+|%# ]</value>
+    <value>The Page URL entered contains characters which cannot be used in a URL or are illegal characters for a URL.   These characters have been removed.  Click the Update button again to accept the modified URL.</value>
   </data>
   <data name="CustomUrlPortalAlias.Error" xml:space="preserve">
     <value>Please select a valid site alias for this custom URL.</value>


### PR DESCRIPTION
Fixes #1029 

## Summary
This issue is very obscure. The error message is misleading.

The URL is rejected because of a hidden host setting named AUM_ReplaceChars which has a default value of
 &$+,/?~#<>()¿¡«»!"
(including a space at the beginning)

URLs are tested against the above characters. In a nutshell, the above characters are replaced with a hyphen when found in the URL.

The other aspect of this issue is that the validation logic returns a suggested modified URL to the front-end, which is completely ignored.

@daguiler Suggested:

I think the easiest way to fix this without introducing breaking changes is
1- to change the error message so that it doesn't specify which characters are "illegal", (**Fixed**)
2- and also, replace the user-provided URL with the suggested modified URL in case there were validation errors. (**Fixed**)

[Fix Video](https://drive.google.com/open?id=1_VUV9xKx4sv7ZWCWKYQ7FJKl7Z8TrC_e)