### PR TITLE
Fix add user admin form is not display when toggle "Assign Current User as Administrator" to off

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Sites.Web/src/components/CreatePortal/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Sites.Web/src/components/CreatePortal/index.jsx
@@ -325,7 +325,7 @@ class CreatePortal extends Component {
                                 value={state.newPortal.UseCurrentUserAsAdmin}
                                 onChange={this.onChange.bind(this, "UseCurrentUserAsAdmin")}
                                 />
-                            <Collapse style={{ float: "left" }} isOpened={!state.newPortal.UseCurrentUserAsAdmin}>
+                            <Collapse style={{ float: "left" }} isOpened={!state.newPortal.UseCurrentUserAsAdmin} fixedHeight={270}>
                                 <GridSystem className="with-right-border top-half">
                                     <GridCell>
                                         <SingleLineInputWithError


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #1054 

## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
- Add fixedHeight to fix the issue 

Observation: GridSystem and GridCell within Collapsible required to set fixedHeight because height calculation is always zero. 

Confirmation video: https://drive.google.com/open?id=11XOMzx8Yrqq3i-TBxjoSQeEuphwdCeXc