### PR TITLE
Enables searching for any type of user

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/src/components/FiltersBar/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Users.Web/src/_exportables/src/components/FiltersBar/index.jsx
@@ -82,8 +82,7 @@ class FiltersBar extends Component {
                 <div>&nbsp; </div></GridCell>
             <GridCell columnSize={35} >
                 <div className="search-filter">
-                    {(this.state.selectedUserFilter.value === 0 || this.state.selectedUserFilter.value === 5) &&
-                        <SearchBox placeholder={Localization.get("SearchPlaceHolder")} onSearch={this.onKeywordChanged.bind(this)} maxLength={50} iconStyle={{ right: 0 }} />}
+                    <SearchBox placeholder={Localization.get("SearchPlaceHolder")} onSearch={this.onKeywordChanged.bind(this)} maxLength={50} iconStyle={{ right: 0 }} />
                     <div className="clear"></div>
                 </div>
             </GridCell>


### PR DESCRIPTION
## Summary
Enables searching for any type of user in the Users Persona Bar module. I have no clue why we could only do it for some types, it works for all types.

Closes #1062 

Closes https://github.com/dnnsoftware/Dnn.Platform/issues/2843 too