### PR TITLE
Link to DNNdocs

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Licensing.Web/src/components/platform/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Licensing.Web/src/components/platform/index.jsx
@@ -39,7 +39,7 @@ class Platform extends Component {
     }
 
     onDocCenterClick() {
-        window.open("http://www.dnnsoftware.com/docs/", "_blank");
+        window.open("https://www.dnndocs.com/", "_blank");
     }
 
     /* eslint-disable react/no-danger */


### PR DESCRIPTION
I think the link to documentation should be a link to DNNDocs

## Summary
<!-- 
Just changed the link to DNNDocs-->
