### PR TITLE
DNN-31578 - Deleted page can still be selected as parent page - second repository

### DIFF
--- a/Dnn.React.Common/src/PagePicker/index.jsx
+++ b/Dnn.React.Common/src/PagePicker/index.jsx
@@ -732,7 +732,8 @@ PagePicker.defaultProps = {
         excludeAdminTabs: false,
         disabledNotSelectable: false,
         roles: "1;-1",
-        sortOrder: 0
+        sortOrder: 0,
+        includeDeletedChildren: true
     },
     selectedTabId: -1
 };

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/PageDetails/PageStandard/PageStandard.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/PageDetails/PageStandard/PageStandard.jsx
@@ -50,7 +50,10 @@ class PageDetails extends Component {
             includeDisabled: true
         };
 
-        let TabParameters_1 = Object.assign(Object.assign({}, TabParameters), { disabledNotSelectable: false });
+        let TabParameters_1 = Object.assign(Object.assign({}, TabParameters), { 
+            disabledNotSelectable: false,
+            includeDeletedChildren: false
+        });
         const sf = Utils.getServiceFramework();
 
         const defaultLabel = page.hierarchy || Localization.get("NoneSpecified");

--- a/Library/Dnn.PersonaBar.UI/Services/TabsController.cs
+++ b/Library/Dnn.PersonaBar.UI/Services/TabsController.cs
@@ -54,10 +54,11 @@ namespace Dnn.PersonaBar.UI.Services
         /// <param name="includeHostPages"></param>
         /// <param name="includeDisabled"></param>
         /// <param name="includeDeleted"></param>
+        /// <param name="includeDeletedChildren"></param>
         /// <returns>List of portal tabs</returns>
         [HttpGet]
         public HttpResponseMessage GetPortalTabs(int portalId, string cultureCode, bool isMultiLanguage = false,
-            bool excludeAdminTabs = true, string roles = "", bool disabledNotSelectable = false, int sortOrder = 0, int selectedTabId = -1, string validateTab="", bool includeHostPages = false, bool includeDisabled = false, bool includeDeleted = false)
+            bool excludeAdminTabs = true, string roles = "", bool disabledNotSelectable = false, int sortOrder = 0, int selectedTabId = -1, string validateTab="", bool includeHostPages = false, bool includeDisabled = false, bool includeDeleted = false, bool includeDeletedChildren = true)
         {
             try
             {
@@ -72,7 +73,7 @@ namespace Dnn.PersonaBar.UI.Services
                     Results =
                         _controller.GetPortalTabs(UserInfo, portalId < 0 ? PortalId : portalId, cultureCode, isMultiLanguage,
                             excludeAdminTabs, roles,
-                            disabledNotSelectable, sortOrder, selectedTabId, validateTab, includeHostPages, includeDisabled, includeDeleted)
+                            disabledNotSelectable, sortOrder, selectedTabId, validateTab, includeHostPages, includeDisabled, includeDeleted, includeDeletedChildren)
                 };
 
                 return Request.CreateResponse(HttpStatusCode.OK, response);
@@ -159,10 +160,11 @@ namespace Dnn.PersonaBar.UI.Services
         /// <param name="validateTab"></param>
         /// <param name="includeHostPages"></param>
         /// <param name="includeDisabled"></param>
+        /// <param name="includeDeletedChildren"></param>
         /// <returns></returns>
         [HttpGet]
         public HttpResponseMessage GetTabsDescendants(int portalId, int parentId, string cultureCode,
-            bool isMultiLanguage = false, string roles = "", bool disabledNotSelectable = false, int sortOrder = 0, string validateTab = "", bool includeHostPages = false, bool includeDisabled = false)
+            bool isMultiLanguage = false, string roles = "", bool disabledNotSelectable = false, int sortOrder = 0, string validateTab = "", bool includeHostPages = false, bool includeDisabled = false, bool includeDeletedChildren = true)
         {
             try
             {
@@ -171,7 +173,7 @@ namespace Dnn.PersonaBar.UI.Services
                     Success = true,
                     Results =
                         _controller.GetTabsDescendants(portalId < 0 ? PortalId : portalId, parentId, cultureCode, isMultiLanguage, roles,
-                            disabledNotSelectable, sortOrder, validateTab, includeHostPages, includeDisabled)
+                            disabledNotSelectable, sortOrder, validateTab, includeHostPages, includeDisabled, includeDeletedChildren)
                 };
 
                 return Request.CreateResponse(HttpStatusCode.OK, response);


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Partially Fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2919 (There are total 2 PRs; for the other PR, you can check: https://github.com/dnnsoftware/Dnn.Platform/pull/2920 ).
## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
A new parameter named as "includeDeletedChildren" is added to filter out the deleted child pages.

Demo: https://drive.google.com/open?id=1yg6OuVuLMbwCbBlFHXDqQa8Abd3WPIn_

Note: This PR should be merged AFTER https://github.com/dnnsoftware/Dnn.Platform/pull/2920 (or the retargeted one: https://github.com/dnnsoftware/Dnn.Platform/pull/2925 ). CI fails since the dependent PR is not merged yet.