### PR TITLE
DNN-28934: Fix Export to PDF Issue on SQL Console Issue

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SqlConsole/scripts/jspdf.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.SqlConsole/scripts/jspdf.js
@@ -13446,9 +13446,10 @@ Q\n";
     NodeParser.prototype.paintText = function(container) {
         container.applyTextTransform();
         var characters = window.html2canvas.punycode.ucs2.decode(container.node.data);
-        var textList = (!this.options.letterRendering || noLetterSpacing(container)) && !hasUnicode(container.node.data) ? getWords(characters) : characters.map(function(character) {
-            return window.html2canvas.punycode.ucs2.encode([character]);
-        });
+        
+		var textList = characters.map(function(character) {
+			return window.html2canvas.punycode.ucs2.encode([character]);
+		});
 
         var weight = container.parent.fontWeight();
         var size = container.parent.css('fontSize');


### PR DESCRIPTION
Fixes #1092 

## Summary
The word-based encoding/rendering option `getWords(characters)` is removed as it should always be based on characters only to wrap long texts without separators and/or spaces.

**[Confirmation Video](https://drive.google.com/open?id=1tEHOU16bYb7w_i47z_MuhqdwInYjSDB8)**