### PR TITLE
DNN-29164 - Open page settings can't display data for correct page

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/App.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/App.jsx
@@ -93,7 +93,7 @@ class App extends Component {
         window.dnn.utility.setConfirmationDialogPosition();
         window.dnn.utility.closeSocialTasks();
         this.props.getPageList().then(() => {
-            const selectedPageId = utils.getCurrentPageId();
+            const selectedPageId = utils.getSelectedPageId() || utils.getCurrentPageId();
             selectedPageId && !utils.getIsAdminHostSystemPage() && this.onLoadPage(selectedPageId);
         
             if (viewName === "edit") {

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/utils.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/utils.js
@@ -99,6 +99,11 @@ function getCurrentPageId() {
     return parseInt(config.tabId);
 }
 
+function getSelectedPageId() {
+    checkInit();
+    return viewParams && viewParams.pageId ? parseInt(viewParams.pageId) : null;
+}
+
 function getViewName() {
     checkInit();
     return viewName;
@@ -211,6 +216,7 @@ const utils = {
     getUtilities,
     getModuleName,
     getCurrentPageId,
+    getSelectedPageId,
     getViewName,
     closePersonaBar,
     getViewParams,


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #1116
## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
When the script got loaded the first time, a wrong page id was getting sent in the XHR request which caused this issue (there were multiple page requests being sent and the order of responses for that requests play an important role in this bug's intermittent occurrence). 

Demo: https://drive.google.com/open?id=1RvwR04B8iPrDdqrMAInCK3N0kN1cWMe2