### PR TITLE
DNN-30135 - Issue when loading the Persona Bar: Not Thread Safe

### DIFF
--- a/Library/Dnn.PersonaBar.Library/Repository/PersonaBarRepository.cs
+++ b/Library/Dnn.PersonaBar.Library/Repository/PersonaBarRepository.cs
@@ -67,12 +67,12 @@ namespace Dnn.PersonaBar.Library.Repository
 
         public MenuItem GetMenuItem(string identifier)
         {
-            return GetMenu().AllItems.FirstOrDefault(m => m.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase));
+            return GetMenu().AllItems.ToList().FirstOrDefault(m => m.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public MenuItem GetMenuItem(int menuId)
         {
-            return GetMenu().AllItems.FirstOrDefault(m => m.MenuId == menuId);
+            return GetMenu().AllItems.ToList().FirstOrDefault(m => m.MenuId == menuId);
         }
 
         public void SaveMenuItem(MenuItem item)


### PR DESCRIPTION
<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->
Fixes #1125 
## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  
  Any new unit tests will be highly appreciated.
-->
The problem lies in "Dnn.PersonaBar.Library.Repository.PersonaBarRepository.GetMenuItem(string identifier)" method which is called from "Evoq.PersonaBar.UI.Controllers.EvoqPersonaBarContainer.Initialize(UserControl personaBarControl)". GetMenuItem method doesn't exist in the StackTrace because JIT (Just-In-Time) Compiler does Inline Code Optimizations for release builds which basically means that some methods (especially like the ones that are only a few lines) get inlined into the previous method chain for performance reasons. Therefore, if you have a method call chain like A -> B -> C, it might become A -> B if C is inlined (you might think of it as method C's code gets copied under method B). 

Using a list instance which might change state in loops (FirstOrDefault method iterates the elements one by one which behaves like a loop) will raise that error when the list gets updated while iterating. The solution is to use ToList method to copy the list's current state into another list and then use it instead for iteration. You can watch the following video I shot which demonstrates the issue: https://drive.google.com/open?id=13bneeDRu2aqicSvJ-QtV2okoPUivkHh4