### PR TITLE
Search crawlers fails when running on different instances of web farm

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Services/TaskSchedulerController.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Services/TaskSchedulerController.cs
@@ -263,7 +263,9 @@ namespace Dnn.PersonaBar.TaskScheduler.Services
         {
             try
             {
-                ScheduleItem scheduleItem = SchedulingProvider.Instance().GetSchedule(scheduleId);
+                var scheduleItem = SchedulingProvider.Instance().GetSchedule(scheduleId);
+
+                var recommendedServers = _controller.GetRecommendedServers(scheduleItem.ScheduleID);
 
                 var response = new
                 {
@@ -284,7 +286,8 @@ namespace Dnn.PersonaBar.TaskScheduler.Services
                         scheduleItem.AttachToEvent,
                         scheduleItem.CatchUpEnabled,
                         scheduleItem.ObjectDependencies,
-                        scheduleItem.Servers
+                        scheduleItem.Servers,
+                        RecommendedServers = recommendedServers
                     },
                     TotalResults = 1
                 };

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/body/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/body/index.jsx
@@ -12,7 +12,7 @@ import TopPane from "../topPane";
 import { DnnTabs as Tabs, PersonaBarPageBody } from "@dnnsoftware/dnn-react-common";
 import "./style.less";
 import resx from "../../resources";
-import util from "../../utils";
+import { util } from "../../utils";
 
 export class Body extends Component {
     constructor() {

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/scheduler/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/scheduler/index.jsx
@@ -8,7 +8,7 @@ import SchedulerRow from "./schedulerRow";
 import { Dropdown, Collapsible, SvgIcons } from "@dnnsoftware/dnn-react-common";
 import SchedulerEditor from "./schedulerEditor";
 import "./style.less";
-import util from "../../utils";
+import { util } from "../../utils";
 import resx from "../../resources";
 
 let tableFields = [];

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/scheduler/schedulerEditor/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/scheduler/schedulerEditor/index.jsx
@@ -14,7 +14,7 @@ import History from "../../history";
 import {
     task as TaskActions
 } from "../../../actions";
-import util from "../../../utils";
+import { util, formatString } from "../../../utils";
 import resx from "../../../resources";
 
 const re = /^[1-9][0-9]?[0-9]?[0-9]?[0-9]?[0-9]?$/;
@@ -203,7 +203,36 @@ class SchedulerEditor extends Component {
             return;
         }
 
-        props.onUpdate(props.scheduleItemDetail);
+        this.handleRecommendedServers(() => props.onUpdate(props.scheduleItemDetail));
+    }
+
+    handleRecommendedServers(callback) {
+        const { scheduleItemDetail } = this.props;
+        const runCallback = function () {
+            if (callback && typeof(callback) === "function") {
+                callback();
+            }
+        };
+        const compare = function (prev, next) {
+            return prev.toLowerCase().localeCompare(next.toLowerCase());
+        };
+
+        if ((scheduleItemDetail.RecommendedServers || []).length > 0) {
+            const servers = scheduleItemDetail.Servers ? 
+                scheduleItemDetail.Servers.split(",").filter(function (e) { return e; }).sort(compare) : [];
+            const recommendedServers = scheduleItemDetail.RecommendedServers.sort(compare);
+
+            if (JSON.stringify(servers).toLowerCase() !== 
+                JSON.stringify(recommendedServers).toLowerCase()) {
+                util.utilities.confirm(formatString(resx.get("RecommendServers"), recommendedServers.join(", ")), resx.get("Yes"), resx.get("No"), () => {
+                    runCallback();
+                });
+            } else {
+                runCallback();
+            }
+        } else {
+            runCallback();
+        }
     }
 
     onCancel() {

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/scheduler/schedulerRow/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/scheduler/schedulerRow/index.jsx
@@ -7,7 +7,7 @@ import resx from "../../../resources";
 import {
     task as TaskActions
 } from "../../../actions";
-import util from "../../../utils";
+import { util } from "../../../utils";
 
 /*eslint-disable quotes*/
 const svgIcon = require(`!raw-loader!./../../svg/checkmark.svg`).default;

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/topPane/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/topPane/index.jsx
@@ -7,7 +7,7 @@ import {
 import styles from "./style.less";
 import { Button, TextOverflowWrapper } from "@dnnsoftware/dnn-react-common";
 import ModePanel from "./modePanel";
-import util from "../../utils";
+import { util } from "../../utils";
 import resx from "../../resources";
 
 /*eslint-disable quotes*/

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/topPane/modePanel/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/components/topPane/modePanel/index.jsx
@@ -6,7 +6,7 @@ import "./style.less";
 import {
     task as TaskActions
 } from "../../../actions";
-import util from "../../../utils";
+import { util } from "../../../utils";
 import resx from "../../../resources";
 
 const re = /^([0-9]|[1-9][0-9]|[1-9][0-9][0-9]|[1-9][0-4][0-4][0])$/;

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/globals/application.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/globals/application.js
@@ -1,4 +1,4 @@
-import utilities from "../utils";
+import { util } from "../utils";
 const boilerPlate = {
     init() {
         // This setting is required and define the public path 
@@ -7,8 +7,8 @@ const boilerPlate = {
         // __webpack_public_path__ = options.publicPath;        
         let options = window.dnn.initScheduler();
 
-        utilities.init(options.utility);
-        utilities.moduleName = options.moduleName;
+        util.init(options.utility);
+        util.moduleName = options.moduleName;
 
         // delay the styles loading after the __webpack_public_path__ is set
         // this allows the fonts associated to be loaded properly in production

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/resources/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/resources/index.jsx
@@ -1,4 +1,4 @@
-import util from "../utils";
+import { util } from "../utils";
 
 const resx = {
     get(key) {

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/services/applicationService.js
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/services/applicationService.js
@@ -1,4 +1,4 @@
-import util from "../utils";
+import { util } from "../utils";
 function serializeQueryStringParameters(obj) {
     let s = [];
     for (let p in obj) {

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/utils/index.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/TaskScheduler.Web/src/utils/index.jsx
@@ -1,4 +1,13 @@
-const utils = {
+export function formatString() {
+    let format = arguments[0];
+    let methodsArgs = arguments;
+    return format.replace(/[{[](\d+)[\]}]/gi, function (value, index) {
+        let argsIndex = parseInt(index) + 1;
+        return methodsArgs[argsIndex];
+    });
+}
+
+export const util = {
     init(utilities) {
         if (!utilities) {
             throw new Error("Utilities is undefined.");
@@ -7,4 +16,3 @@ const utils = {
     },
     utilities: null
 };
-export default utils;

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.TaskScheduler/App_LocalResources/TaskScheduler.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.TaskScheduler/App_LocalResources/TaskScheduler.resx
@@ -511,7 +511,7 @@
     <value>Stop Schedule</value>
   </data>
   <data name="RecommendServers.Text" xml:space="preserve">
-    <value>To avoid failures it is highly recommended to setup scheduler to run on a following web server: {0}. Would you like to proceed without changing?</value>
+    <value>To avoid failures it is highly recommended to setup scheduler to run on a following web server: {0}. Would you like to proceed without changes?</value>
   </data>
   <data name="lblStartDelay.Text" xml:space="preserve">
     <value>Schedule Start Delay (mins):</value>

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.TaskScheduler/App_LocalResources/TaskScheduler.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.TaskScheduler/App_LocalResources/TaskScheduler.resx
@@ -510,6 +510,9 @@
   <data name="StopSchedule.Text" xml:space="preserve">
     <value>Stop Schedule</value>
   </data>
+  <data name="RecommendServers.Text" xml:space="preserve">
+    <value>To avoid failures it is highly recommended to setup scheduler to run on a following web server: {0}. Would you like to proceed without changing?</value>
+  </data>
   <data name="lblStartDelay.Text" xml:space="preserve">
     <value>Schedule Start Delay (mins):</value>
   </data>


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.Platform/issues/2961

Issue fixed by checking whether `SchedulersToRunOnSameWebServer` host setting exists and creating list of recommended servers to be provided to client side. 
When saving Scheduler settings on UI, system validates whether entered Server matches to the servers configured for other schedulers in that list.

See demo: [DEMO](https://drive.google.com/file/d/1c716ocdbknBIaEwoy-Qv8wuMplebCqQO/view?usp=sharing)