### PR TITLE
Social Groups created through the Persona Bar do not appear in the Social Groups

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Roles/RolesController.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Roles/RolesController.cs
@@ -192,9 +192,10 @@ namespace Dnn.PersonaBar.Roles.Components
             Requires.NotNull("role", role);
 
             var parentFolder = FolderManager.Instance.GetFolder(role.PortalID, "Groups");
-            var portalFolder = FolderManager.Instance.GetFolder(role.PortalID, "");
+            
             if (parentFolder == null)
             {
+                var portalFolder = FolderManager.Instance.GetFolder(role.PortalID, string.Empty);
                 parentFolder = AssetManager.Instance.CreateFolder(role.RoleID.ToString(),
                     portalFolder.FolderID,
                     portalFolder.FolderMappingID,
@@ -204,7 +205,7 @@ namespace Dnn.PersonaBar.Roles.Components
             AssetManager.Instance.CreateFolder(role.RoleID.ToString(),
                 parentFolder.FolderID,
                 parentFolder.FolderMappingID,
-                "");
+                string.Empty);
 
             RoleController.Instance.AddUserRole(role.PortalID,
                 userId,

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Roles/RolesController.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Roles/RolesController.cs
@@ -26,11 +26,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Dnn.PersonaBar.Roles.Services.DTO;
+using DotNetNuke.Common;
 using DotNetNuke.Common.Utilities;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using DotNetNuke.Framework;
 using DotNetNuke.Security.Roles;
+using DotNetNuke.Services.Assets;
+using DotNetNuke.Services.FileSystem;
 using DotNetNuke.Services.Localization;
 
 #endregion
@@ -170,7 +173,46 @@ namespace Dnn.PersonaBar.Roles.Components
                     return false;
                 }
             }
+
+            if (roleDto.IsPublic && roleDto.SecurityMode == SecurityMode.SocialGroup)
+            {
+                AddSocialRole(role, portalSettings.UserId);
+            }
+
             return true;
+        }
+
+        /// <summary>
+        /// Add Role to Social Group, create folder(s) for it and adds user created role as owner.
+        /// </summary>
+        /// <param name="role"></param>
+        /// <param name="userId"></param>
+        public void AddSocialRole(RoleInfo role, int userId)
+        {
+            Requires.NotNull("role", role);
+
+            var parentFolder = FolderManager.Instance.GetFolder(role.PortalID, "Groups");
+            var portalFolder = FolderManager.Instance.GetFolder(role.PortalID, "");
+            if (parentFolder == null)
+            {
+                parentFolder = AssetManager.Instance.CreateFolder(role.RoleID.ToString(),
+                    portalFolder.FolderID,
+                    portalFolder.FolderMappingID,
+                    "");
+            }
+
+            AssetManager.Instance.CreateFolder(role.RoleID.ToString(),
+                parentFolder.FolderID,
+                parentFolder.FolderMappingID,
+                "");
+
+            RoleController.Instance.AddUserRole(role.PortalID,
+                userId,
+                role.RoleID,
+                RoleStatus.Approved,
+                true,
+                Null.NullDate,
+                Null.NullDate);
         }
 
         public string DeleteRole(PortalSettings portalSettings, int roleId, out KeyValuePair<HttpStatusCode, string> message)

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Roles/RolesController.cs
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/Components/Roles/RolesController.cs
@@ -199,7 +199,7 @@ namespace Dnn.PersonaBar.Roles.Components
                 parentFolder = AssetManager.Instance.CreateFolder(role.RoleID.ToString(),
                     portalFolder.FolderID,
                     portalFolder.FolderMappingID,
-                    "");
+                    string.Empty);
             }
 
             AssetManager.Instance.CreateFolder(role.RoleID.ToString(),


### PR DESCRIPTION
Social Groups created through the Persona Bar do not appear in the Social Groups fixed
https://github.com/dnnsoftware/Dnn.Platform/issues/3007
https://jira.devfactory.com/browse/DNN-30220

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/development/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->

## Summary
1) Create the role with Security Mode = Social Group, Status = Approved, Public
2) Get RoleID and UserId from created role.
3) Add  Groups folder, if it doesn't exists. Add the folder with name equal to RoleID. 
4) Add creator as owner to the Social Group(role)
