### PR TITLE
Added message after localization update finishes

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/PageLocalization/PageLocalization.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/PageLocalization/PageLocalization.jsx
@@ -142,6 +142,9 @@ class PageLocalization extends Component {
             const params = { Locales, Modules, Pages };
             props.dispatch(LanguagesActions.updateTabLocalization(params, () => {
                 this.getLanguages();
+                utils.notify(Localization.get("UpdateLocalizationSuccess"));
+            }, () => {
+                utils.notifyError(Localization.get("AnErrorOccurred"));
             }));
         });
     }

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/admin/personaBar/Dnn.Pages/App_LocalResources/Pages.resx
@@ -159,6 +159,9 @@
   <data name="UpdateLocalizationWarning.Text" xml:space="preserve">
     <value>Updating localization might take a few minutes depending on the number of modules. Please wait until the process finishes completely.</value>
   </data>
+  <data name="UpdateLocalizationSuccess.Text" xml:space="preserve">
+    <value>Done!</value>
+  </data>
   <data name="DragPageTooltip.Text" xml:space="preserve">
     <value>Drag Page into Location</value>
   </data>


### PR DESCRIPTION
Fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/1171

## Summary
Following notification message is now displayed when localization update finishes:

![dnn-33474](https://user-images.githubusercontent.com/30123437/65627995-e91bf700-dfa6-11e9-94f8-aec768b4e7a0.png)
