### PR TITLE
Expand All Fails After Adding Multiple Pages

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
@@ -40,7 +40,7 @@ class PersonaBarPageTreeviewInteractor extends Component {
         this.init();
     }
 
-    static getDerivedStateFromProps(props) {
+    static getDerivedStateFromProps(props, state) {
         let setTreeViewExpanded = null;
         let pageList = null;   
         const {
@@ -72,12 +72,21 @@ class PersonaBarPageTreeviewInteractor extends Component {
             }
         }, pageListCopy);
 
-        return {
+        const newState = {
             rootLoaded: true,
             isTreeviewExpanded: setTreeViewExpanded,
             initialCollapse: !setTreeViewExpanded,
             pageList: pageList || pageListCopy
+        };
+
+        const prevPageListCount = (state.pageList || []).length;
+        const newPageListCount = (newState.pageList || []).length;
+
+        if (prevPageListCount !== newPageListCount) {
+            return { ...newState, isChildLoaded: false };
         }
+
+        return newState;
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/1112

Summary: 
Issue caused due to `isChildLoaded` state property that we miss to reset when new page is added via `Add multiple pages`. On adding pages, tree view comes with the new pages list, but `isChildLoaded` remains unchanged after the first load. On rendering, it assumes all child items are already loaded, so it does not trigger them to be re-created in the tree. It does not allow Collapse/Expand to work properly.

Solution is to check whether number of pages has been changed. If yes, we reset `isChildLoaded` to `false`. Depending on this flag application will re-create child items on rendering. 

Please, note, this is alternative and much simpler way instead of one proposed here https://github.com/dnnsoftware/Dnn.AdminExperience/pull/1113

See confirmation video: [DEMO](https://drive.google.com/file/d/1S8Jg95dboApz9CTHiUI9K53U9LleV8Jc/view?usp=sharing)