### PR TITLE
Expand/Collapse All Fails After Moving Dragging Away The Only Child item

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
@@ -662,6 +662,11 @@ class PersonaBarPageTreeviewInteractor extends Component {
                 this.setState({
                     isTreeviewExpanded: !this.state.isTreeviewExpanded
                 });
+            } else if (item.childCount === 0) {
+                item.childListItems = [];
+                item.isOpen = false;
+                item.hasChildren = false;
+                updateStore(list);
             }
         });
     }


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/1122

I isolated the fix from here https://github.com/dnnsoftware/Dnn.AdminExperience/pull/1123. It contains redundant changes that are not related to the issue itself.  
When child item has been moved to another item, its parent becomes not properly updated and keeps child properties unchanged. We need to reset few properties to defaults to make Collapse/Expand works properly. 

Confirmation video: [DEMO](https://drive.google.com/file/d/1wQQnH_pGpOWYu6Ij9C9AxaQJFPcx3Icc/view?usp=sharing)