### PR TITLE
UI Issue for Expand All/Collapse All

### DIFF
--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeviewInteractor.jsx
@@ -742,7 +742,7 @@ class PersonaBarPageTreeviewInteractor extends Component {
         return (
             <div
                 onClick={this.props.enabled ? this.toggleExpandAll.bind(this) : () => {}}
-                className="collapse-expand" >
+                className={this.state.initialCollapse ? "collapse-expand initial" : "collapse-expand"}>
                 [{this.state.isTreeviewExpanded ? Localization.get("lblCollapseAll").toUpperCase() : Localization.get("lblExpandAll").toUpperCase()}]
             </div>
         );

--- a/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
+++ b/Extensions/Content/Dnn.PersonaBar.Extensions/WebApps/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
@@ -61,7 +61,6 @@
     }
     .initial {
         color: @alto;
-        cursor: default;
     }
     .item-name {
         position: relative;


### PR DESCRIPTION
fixes https://github.com/dnnsoftware/Dnn.AdminExperience/issues/1183

Summary:
Expand/Collapse is highlighted depending on its state. `Initial` css class has default gray color. I also removed default cursor , so hand pointer will be used. This class is used in this place only.

See [DEMO](https://drive.google.com/file/d/14IKL8GpKV8Al_zkztNkkY8sKDUBZ57bd/view?usp=sharing)